### PR TITLE
Fix user doesn't impersonate.

### DIFF
--- a/src/com/yahoo/ml/tf/TFSparkNode.py
+++ b/src/com/yahoo/ml/tf/TFSparkNode.py
@@ -18,13 +18,12 @@ nodes block on startup, they will not receive any RDD partitions.
 import logging
 import os
 import platform
-import random
 import socket
 import subprocess
 import threading
 import time
 import uuid
-import Queue
+import getpass
 import TFManager
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s (%(threadName)s-%(process)d) %(message)s",)
@@ -191,6 +190,8 @@ def start(fn, tf_args, cluster_info, defaultFS, working_dir, background):
         mgr = _get_manager(cluster_info, host, ppid)
 
         ctx = TFNodeContext(worker_num, job_name, task_index, spec, defaultFS, working_dir, mgr)
+
+        os.environ['HADOOP_USER_NAME'] = getpass.getuser()
 
         # expand Hadoop classpath wildcards for JNI (Spark 2.x)
         if 'HADOOP_PREFIX' in os.environ:


### PR DESCRIPTION
## What changes were proposed in this pull request?

When save model to `HDFS`, It's the user of `yarn`, not the user who submit the application, this PR fix this issue.

Current mater branch:
```
$ hadoop fs -ls /user/tandem/tensorflow/demo/mnist_model
Found 14 items
-rw-r--r--   3 yarn tandem        218 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/checkpoint
-rw-r--r--   3 yarn tandem     117453 2017-03-06 16:38 /user/tandem/tensorflow/demo/mnist_model/graph.pbtxt
-rw-r--r--   3 yarn tandem     814164 2017-03-06 16:38 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-0.data-00000-of-00001
-rw-r--r--   3 yarn tandem        372 2017-03-06 16:38 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-0.index
-rw-r--r--   3 yarn tandem      45555 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-0.meta
-rw-r--r--   3 yarn tandem     814164 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-118.data-00000-of-00001
-rw-r--r--   3 yarn tandem        372 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-118.index
-rw-r--r--   3 yarn tandem      45555 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-118.meta
-rw-r--r--   3 yarn tandem     814164 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-390.data-00000-of-00001
-rw-r--r--   3 yarn tandem        372 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-390.index
-rw-r--r--   3 yarn tandem      45555 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-390.meta
-rw-r--r--   3 yarn tandem     814164 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-572.data-00000-of-00001
-rw-r--r--   3 yarn tandem        372 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-572.index
-rw-r--r--   3 yarn tandem      45555 2017-03-06 16:39 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-572.meta
```

After this PR:
```
$ hadoop fs -ls /user/tandem/tensorflow/demo/mnist_model
Found 16 items
-rw-r--r--   3 tandem tandem        217 2017-03-06 16:28 /user/tandem/tensorflow/demo/mnist_model/checkpoint
-rw-r--r--   3 tandem tandem     117453 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/graph.pbtxt
-rw-r--r--   3 tandem tandem     814164 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-0.data-00000-of-00001
-rw-r--r--   3 tandem tandem        372 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-0.index
-rw-r--r--   3 tandem tandem      45555 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-0.meta
-rw-r--r--   3 tandem tandem     814164 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-147.data-00000-of-00001
-rw-r--r--   3 tandem tandem        372 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-147.index
-rw-r--r--   3 tandem tandem      45555 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-147.meta
-rw-r--r--   3 tandem tandem     814164 2017-03-06 16:28 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-287.data-00000-of-00001
-rw-r--r--   3 tandem tandem        372 2017-03-06 16:28 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-287.index
-rw-r--r--   3 tandem tandem      45555 2017-03-06 16:28 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-287.meta
-rw-r--r--   3 tandem tandem     814164 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-52.data-00000-of-00001
-rw-r--r--   3 tandem tandem        372 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-52.index
-rw-r--r--   3 tandem tandem      45555 2017-03-06 16:27 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-52.meta
-rw-r--r--   3 tandem tandem     814164 2017-03-06 16:28 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-586.data-00000-of-00001
-rw-r--r--   3 tandem tandem        372 2017-03-06 16:28 /user/tandem/tensorflow/demo/mnist_model/model.ckpt-586.index.tempstate17534181068916059182
```

## How was this patch tested?

manual tests