### PR TITLE
new TFCluster.run() api

### DIFF
--- a/examples/cifar10/cifar10_eval.py
+++ b/examples/cifar10/cifar10_eval.py
@@ -165,6 +165,7 @@ if __name__ == '__main__':
   num_executors = int(sc._conf.get("spark.executor.instances"))
   num_ps = 0
 
-  cluster = TFCluster.reserve(sc, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
-  cluster.start(main_fun, sys.argv)
+  #cluster = TFCluster.reserve(sc, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
+  #cluster.start(main_fun, sys.argv)
+  cluster = TFCluster.run(sc, main_fun, sys.argv, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
   cluster.shutdown()

--- a/examples/cifar10/cifar10_multi_gpu_train.py
+++ b/examples/cifar10/cifar10_multi_gpu_train.py
@@ -278,6 +278,7 @@ if __name__ == '__main__':
   num_executors = int(sc._conf.get("spark.executor.instances"))
   num_ps = 0
 
-  cluster = TFCluster.reserve(sc, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
-  cluster.start(main_fun, sys.argv)
+  #cluster = TFCluster.reserve(sc, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
+  #cluster.start(main_fun, sys.argv)
+  cluster = TFCluster.run(sc, main_fun, sys.argv, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
   cluster.shutdown()

--- a/examples/cifar10/cifar10_train.py
+++ b/examples/cifar10/cifar10_train.py
@@ -125,6 +125,7 @@ if __name__ == '__main__':
   num_executors = int(sc._conf.get("spark.executor.instances"))
   num_ps = 0
 
-  cluster = TFCluster.reserve(sc, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
-  cluster.start(main_fun, sys.argv)
+  #cluster = TFCluster.reserve(sc, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
+  #cluster.start(main_fun, sys.argv)
+  cluster = TFCluster.run(sc, main_fun, sys.argv, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
   cluster.shutdown()

--- a/examples/imagenet/inception/imagenet_distributed_train.py
+++ b/examples/imagenet/inception/imagenet_distributed_train.py
@@ -87,8 +87,9 @@ if __name__ == '__main__':
   num_executors = int(sc._conf.get("spark.executor.instances"))
   num_ps = 1
 
-  cluster = TFCluster.reserve(sc, num_executors, num_ps, args.tensorboard, input_mode)
-  cluster.start(main_fun, sys.argv)
+  #cluster = TFCluster.reserve(sc, num_executors, num_ps, args.tensorboard, input_mode)
+  #cluster.start(main_fun, sys.argv)
+  cluster = TFCluster.run(sc, main_fun, sys.argv, num_executors, num_ps, args.tensorboard, input_mode)
   if input_mode == TFCluster.InputMode.SPARK:
     dataRDD = sc.newAPIHadoopFile(args.input_data, "org.tensorflow.hadoop.io.TFRecordFileInputFormat",
                                 keyClass="org.apache.hadoop.io.BytesWritable",

--- a/examples/imagenet/inception/imagenet_eval.py
+++ b/examples/imagenet/inception/imagenet_eval.py
@@ -58,6 +58,7 @@ if __name__ == '__main__':
   num_executors = int(sc._conf.get("spark.executor.instances"))
   num_ps = 0
 
-  cluster = TFCluster.reserve(sc, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
-  cluster.start(main_fun, sys.argv)
+  #cluster = TFCluster.reserve(sc, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
+  #cluster.start(main_fun, sys.argv)
+  cluster = TFCluster.run(sc, main_fun, sys.argv, num_executors, num_ps, False, TFCluster.InputMode.TENSORFLOW)
   cluster.shutdown()

--- a/examples/mnist/spark/mnist_spark.py
+++ b/examples/mnist/spark/mnist_spark.py
@@ -66,9 +66,9 @@ else:
   print("zipping images and labels")
   dataRDD = images.zip(labels)
 
-
-cluster = TFCluster.reserve(sc, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK)
-cluster.start(mnist_dist.map_fun, args)
+#cluster = TFCluster.reserve(sc, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK)
+#cluster.start(mnist_dist.map_fun, args)
+cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK)
 if args.mode == "train":
   cluster.train(dataRDD, args.epochs)
 else:

--- a/examples/mnist/tf/mnist_spark.py
+++ b/examples/mnist/tf/mnist_spark.py
@@ -44,8 +44,9 @@ print("args:",args)
 
 print("{0} ===== Start".format(datetime.now().isoformat()))
 
-cluster = TFCluster.reserve(sc, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.TENSORFLOW)
-cluster.start(mnist_dist.map_fun, args)
+#cluster = TFCluster.reserve(sc, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.TENSORFLOW)
+#cluster.start(mnist_dist.map_fun, args)
+cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.TENSORFLOW)
 cluster.shutdown()
 
 print("{0} ===== Stop".format(datetime.now().isoformat()))

--- a/examples/slim/eval_image_classifier.py
+++ b/examples/slim/eval_image_classifier.py
@@ -199,6 +199,7 @@ def main_fun(argv, ctx):
 if __name__ == '__main__':
   sc = SparkContext(conf=SparkConf().setAppName("eval_image_classifier"))
   num_executors = int(sc._conf.get("spark.executor.instances"))
-  cluster = TFCluster.reserve(sc, num_executors, 0, False, TFCluster.InputMode.TENSORFLOW)
-  cluster.start(main_fun, sys.argv)
+  #cluster = TFCluster.reserve(sc, num_executors, 0, False, TFCluster.InputMode.TENSORFLOW)
+  #cluster.start(main_fun, sys.argv)
+  cluster = TFCluster.run(sc, main_fun, sys.argv, num_executors, 0, False, TFCluster.InputMode.TENSORFLOW)
   cluster.shutdown()

--- a/examples/slim/train_image_classifier.py
+++ b/examples/slim/train_image_classifier.py
@@ -617,6 +617,7 @@ if __name__ == '__main__':
   (args,rem) = parser.parse_known_args()
 
   assert(num_executors > args.num_ps_tasks)
-  cluster = TFCluster.reserve(sc, args.cluster_size, args.num_ps_tasks, args.tensorboard, TFCluster.InputMode.TENSORFLOW)
-  cluster.start(main_fun, sys.argv)
+  #cluster = TFCluster.reserve(sc, args.cluster_size, args.num_ps_tasks, args.tensorboard, TFCluster.InputMode.TENSORFLOW)
+  #cluster.start(main_fun, sys.argv)
+  cluster = TFCluster.run(sc, main_fun, sys.argv, args.cluster_size, args.num_ps_tasks, args.tensorboard, TFCluster.InputMode.TENSORFLOW)
   cluster.shutdown()

--- a/src/com/yahoo/ml/tf/TFSparkNode.py
+++ b/src/com/yahoo/ml/tf/TFSparkNode.py
@@ -29,6 +29,7 @@ import multiprocessing
 import time
 import uuid
 from . import TFManager
+from . import reservation
 
 class TFNodeContext:
   """This encapsulates key metadata for each TF node"""
@@ -238,6 +239,176 @@ def start(fn, tf_args, cluster_info, defaultFS, working_dir, background):
             logging.info("Finished TensorFlow {0}:{1} on cluster node {2}".format(job_name, task_index, worker_num))
 
         return [(worker_num, job_name, task_index)]
+
+    return _mapfn
+
+def run(fn, tf_args, cluster_meta, tensorboard, queues, background):
+    """
+    Wraps the TensorFlow main function in a Spark mapPartitions-compatible function.
+    """
+    def _mapfn(iter):
+        # Note: consuming the input iterator helps Pyspark re-use this worker,
+        for i in iter:
+            worker_num = i
+
+        # assign TF job/task based on provided cluster_spec template (or use default/null values)
+        job_name = 'default'
+        task_index = -1
+        cluster_id = cluster_meta['id']
+        cluster_template = cluster_meta['cluster_template']
+        for jobtype in cluster_template:
+            nodes = cluster_template[jobtype]
+            if worker_num in nodes:
+               job_name = jobtype
+               task_index = nodes.index(worker_num)
+               break;
+
+        # get unique id (hostname,ppid) for this executor's JVM
+        host = socket.gethostname()
+        ppid = os.getppid()
+        port = 0
+
+        # check for existing TFManagers
+        if TFSparkNode.mgr is not None and str(TFSparkNode.mgr.get('state')) != "'stopped'":
+            if TFSparkNode.cluster_id == cluster_id:
+                # raise an exception to force Spark to retry this "reservation" task on another executor
+                raise Exception("TFManager already started on {0}, ppid={1}, state={2}".format(host, ppid, str(TFSparkNode.mgr.get("state"))))
+            else:
+                # old state, just continue with creating new manager
+                logging.warn("Ignoring old TFManager with cluster_id {0}, requested cluster_id {1}".format(TFSparkNode.cluster_id, cluster_id))
+
+        # start a TFManager and get a free port
+        # use a random uuid as the authkey
+        authkey = uuid.uuid4().bytes
+        addr = None
+        if job_name == 'ps':
+            # PS nodes must be remotely accessible in order to shutdown from Spark driver.
+            TFSparkNode.mgr = TFManager.start(authkey, ['control'], 'remote')
+            addr = (host, TFSparkNode.mgr.address[1])
+        else:
+            # worker nodes only need to be locally accessible within the executor for data feeding
+            TFSparkNode.mgr = TFManager.start(authkey, queues)
+            addr = TFSparkNode.mgr.address
+
+        # initialize mgr state
+        TFSparkNode.mgr.set('state', 'running')
+        TFSparkNode.cluster_id = cluster_id
+
+        # start TensorBoard if requested
+        tb_pid = 0
+        tb_port = 0
+        if tensorboard and job_name == 'worker' and task_index == 0:
+            tb_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            tb_sock.bind(('',0))
+            tb_port = tb_sock.getsockname()[1]
+            tb_sock.close()
+            logdir = "tensorboard_%d" %(worker_num)
+
+            if 'PYSPARK_PYTHON' in os.environ:
+              # user-specified Python (typically Python.zip)
+              pypath = os.environ['PYSPARK_PYTHON']
+              logging.info("PYSPARK_PYTHON: {0}".format(pypath))
+              pydir = os.path.dirname(pypath)
+              tb_proc = subprocess.Popen([pypath, "%s/tensorboard"%pydir, "--logdir=%s"%logdir, "--port=%d"%tb_port, "--debug"])
+            else:
+              # system-installed Python & tensorboard
+              tb_proc = subprocess.Popen(["tensorboard", "--logdir=%s"%logdir, "--port=%d"%tb_port, "--debug"])
+            tb_pid = tb_proc.pid
+
+        # check server to see if this task is being retried (i.e. already reserved)
+        client = reservation.Client(cluster_meta['server_addr'])
+        cluster_info = client.get_reservations()
+        node_meta = None
+        for node in cluster_info:
+            (nhost, nppid) = (node['host'], node['ppid'])
+            if nhost == host and nppid == ppid:
+              node_meta = node
+              port = node['port']
+
+        # find a free port for TF
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(('',port))
+        port = s.getsockname()[1]
+
+        # if not already done, register everything we need to set up the cluster
+        if node_meta is None:
+          node_meta = {
+              'worker_num': worker_num,
+              'host': host,
+              'ppid': ppid,
+              'job_name': job_name,
+              'task_index': task_index,
+              'port': port,
+              'tb_pid': tb_pid,
+              'tb_port': tb_port,
+              'addr': addr,
+              'authkey': authkey
+          }
+          # register node metadata with server
+          logging.info("TFSparkNode.reserve: {0}".format(node_meta))
+          client.register(node_meta)
+          # wait for other nodes to finish reservations
+          cluster_info = client.await_reservations()
+          client.close()
+
+        # construct a TensorFlow clusterspec from cluster_info
+        sorted_cluster_info = sorted(cluster_info, key=lambda k: k['worker_num'])
+        spec = {}
+        for node in sorted_cluster_info:
+            logging.info("node: {0}".format(node))
+            (njob, nhost, nport) = (node['job_name'], node['host'], node['port'])
+            hosts = [] if njob not in spec else spec[njob]
+            hosts.append("{0}:{1}".format(nhost, nport))
+            spec[njob] = hosts
+
+        # expand Hadoop classpath wildcards for JNI (Spark 2.x)
+        if 'HADOOP_PREFIX' in os.environ:
+            classpath = os.environ['CLASSPATH']
+            hadoop_path = os.path.join(os.environ['HADOOP_PREFIX'], 'bin', 'hadoop')
+            hadoop_classpath = subprocess.check_output([hadoop_path, 'classpath', '--glob']).decode()
+            logging.debug("CLASSPATH: {0}".format(hadoop_classpath))
+            os.environ['CLASSPATH'] = classpath + os.pathsep + hadoop_classpath
+
+        # create a context object to hold metadata for TF
+        ctx = TFNodeContext(worker_num, job_name, task_index, spec, cluster_meta['default_fs'], cluster_meta['working_dir'], TFSparkNode.mgr)
+
+        # release port reserved for TF as late as possible
+        s.close()
+
+        # Background mode relies reuse of python worker in Spark.
+        if background:
+            # However, reuse of python worker can't work on Windows, we need to check if the current
+            # script runs on Windows or not.
+            if os.name == 'nt' or platform.system() == 'Windows':
+                raise Exception("Background mode is not supported on Windows.")
+            # Check if the config of reuse python worker is enabled on Spark.
+            if not os.environ.get("SPARK_REUSE_WORKER"):
+                raise Exception("Background mode relies reuse of python worker on Spark. This config 'spark.python.worker.reuse' is not enabled on Spark. Please enable it before using background.")
+
+        if job_name == 'ps' or background:
+            # invoke the TensorFlow main function in a background thread
+            logging.info("Starting TensorFlow {0}:{1} on cluster node {2} on background process".format(job_name, task_index, worker_num))
+            p = multiprocessing.Process(target=fn, args=(tf_args, ctx))
+            p.start()
+
+            # for ps nodes only, wait indefinitely in foreground thread for a "control" event (None == "stop")
+            if job_name == 'ps':
+                queue = TFSparkNode.mgr.get_queue('control')
+                done = False
+                while not done:
+                    msg =  queue.get(block=True)
+                    logging.info("Got msg: {0}".format(msg))
+                    if msg == None:
+                        logging.info("Terminating PS")
+                        TFSparkNode.mgr.set('state', 'stopped')
+                        done = True
+                    queue.task_done()
+        else:
+            # otherwise, just run TF function in the main executor/worker thread
+            logging.info("Starting TensorFlow {0}:{1} on cluster node {2} on foreground thread".format(job_name, task_index, worker_num))
+            fn(tf_args, ctx)
+            logging.info("Finished TensorFlow {0}:{1} on cluster node {2}".format(job_name, task_index, worker_num))
 
     return _mapfn
 

--- a/src/com/yahoo/ml/tf/reservation.py
+++ b/src/com/yahoo/ml/tf/reservation.py
@@ -1,0 +1,186 @@
+# Copyright 2017 Yahoo Inc.
+# Licensed under the terms of the Apache 2.0 license.
+# Please see LICENSE file in the project root for terms.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import nested_scopes
+from __future__ import print_function
+
+import logging
+import pickle
+import select
+import socket
+import struct
+import threading
+import time
+
+BUFSIZE = 1024
+
+class Reservations:
+
+  def __init__(self, required):
+    self.required = required
+    self.lock = threading.RLock()
+    self.reservations = []
+
+  def add(self, meta):
+    with self.lock:
+      self.reservations.append(meta)
+
+  def done(self):
+    with self.lock:
+      return len(self.reservations) >= self.required
+
+  def get(self):
+    with self.lock:
+      return self.reservations
+
+  def remaining(self):
+    with self.lock:
+      return self.required - len(self.reservations)
+
+class MessageSocket(object):
+  """Abstract class w/ length-prefixed socket send/receive functions"""
+
+  def receive(self, sock):
+    msg = None
+    data = b''
+    recv_done = False
+    recv_len = -1
+    while not recv_done:
+      buf = sock.recv(BUFSIZE)
+      if buf == None or len(buf) == 0:
+        raise Exception("socket closed")
+      if recv_len == -1:
+        recv_len = struct.unpack('>I', buf[:4])[0]
+        data += buf[4:]
+        recv_len -= len(data)
+      else:
+        data += buf
+        recv_len -= len(buf)
+      recv_done = (recv_len == 0)
+
+    msg = pickle.loads(data)
+    return msg
+
+  def send(self, sock, msg):
+    data = pickle.dumps(msg)
+    buf = struct.pack('>I', len(data)) + data
+    sock.sendall(buf)
+
+class Server(MessageSocket):
+  """Simple socket server with length prefixed pickle messages"""
+  reservations = None
+  done = False
+
+  def __init__(self, count):
+    assert count > 0
+    self.reservations = Reservations(count)
+
+  def await_reservations(self):
+    """Block until all reservations done"""
+    while not self.reservations.done():
+      logging.info("waiting for {0} reservations".format(self.reservations.remaining()))
+      time.sleep(1)
+    logging.info("all reservations completed")
+    return self.reservations.get()
+
+  def handle_message(self, sock, msg):
+    logging.debug("received: {0}".format(msg))
+    msg_type = msg['type']
+    if msg_type == "REG":
+      self.reservations.add(msg['data'])
+      MessageSocket.send(self, sock, "OK")
+    elif msg_type == "QUERY":
+      MessageSocket.send(self, sock, self.reservations.done())
+    elif msg_type == "QINFO":
+      rinfo = self.reservations.get()
+      MessageSocket.send(self, sock, rinfo)
+    else:
+      MessageSocket.send(self, sock, "ERR")
+
+  def start(self):
+    """Start listener in a background thread"""
+    server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_sock.bind(('',0))
+    server_sock.listen(1)
+
+    host = socket.gethostname()
+    port = server_sock.getsockname()[1]
+    addr = (host,port)
+    logging.info("listening for reservations at {0}".format(addr))
+
+    def _listen(self, sock):
+      CONNECTIONS = []
+      CONNECTIONS.append(sock)
+
+      while not self.done:
+        read_socks, write_socks, err_socks = select.select(CONNECTIONS, [], [], 60)
+        for sock in read_socks:
+          if sock == server_sock:
+            client_sock, client_addr = sock.accept()
+            CONNECTIONS.append(client_sock)
+            logging.debug("client connected from {0}".format(client_addr))
+          else:
+            try:
+              msg = self.receive(sock)
+              self.handle_message(sock, msg)
+            except Exception as e:
+              logging.debug(e)
+              sock.close()
+              CONNECTIONS.remove(sock)
+
+      server_sock.close()
+
+    t = threading.Thread(target=_listen, args=(self, server_sock))
+    t.daemon = True
+    t.start()
+
+    return addr
+
+  def stop(self):
+    """Stop the socket listener"""
+    self.done = True
+
+class Client(MessageSocket):
+  """Client to register/await node reservations"""
+  sock = None
+
+  def __init__(self, server_addr):
+    self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    self.sock.connect(server_addr)
+    logging.info("connected to server at {0}".format(server_addr))
+
+  def _request(self, msg_type, msg_data=None):
+    """Helper function to wrap msg w/ msg_type"""
+    msg = {}
+    msg['type'] = msg_type
+    if msg_data:
+      msg['data'] = msg_data
+    MessageSocket.send(self, self.sock, msg)
+    logging.debug("sent: {0}".format(msg))
+    resp = MessageSocket.receive(self, self.sock)
+    logging.debug("received: {0}".format(resp))
+    return resp
+
+  def close(self):
+    self.sock.close()
+
+  def register(self, reservation):
+    """Register reservation with server"""
+    resp = self._request('REG', reservation)
+    return resp
+
+  def get_reservations(self):
+    """Get current list of reservations"""
+    cluster_info = self._request("QINFO")
+    return cluster_info
+
+  def await_reservations(self):
+    """Poll until all reservations completed, then return cluster_info"""
+    done = False
+    while not done:
+      done = self._request("QUERY")
+      time.sleep(1)
+    return self.get_reservations()


### PR DESCRIPTION
... which combines `reserve` and `start` steps into one call.

This starts a server on the driver to listen for reservations (replacing the `reserve` step). Each executor/node will then reserve a port, report it to the server, and then wait for all other executors to report before starting the TF process on the node.

This resolves:

- most of the "TFManager already started" issues, since the nodes will now block until all other nodes have responded with their port reservations (i.e. guaranteeing even distribution of "reserve" tasks across all executors).
- most of the "socket already in use" issues, since nodes will now hang onto the reserved socket until just prior to starting the TF process on each node (vs. releasing after the reserve step). Note: there's still a chance that another process might take the port, but this window is now much, much smaller than before.

Note: I left the original reserve and start APIs in place for backwards-compatibility reasons.