### PR TITLE
Add extra PATH to find tensorboard

### DIFF
--- a/src/com/yahoo/ml/tf/TFSparkNode.py
+++ b/src/com/yahoo/ml/tf/TFSparkNode.py
@@ -316,6 +316,9 @@ def run(fn, tf_args, cluster_meta, tensorboard, queues, background):
               tb_proc = subprocess.Popen([pypath, "%s/tensorboard"%pydir, "--logdir=%s"%logdir, "--port=%d"%tb_port, "--debug"])
             else:
               # system-installed Python & tensorboard
+              python_path = os.environ['PYTHONPATH'].split(":")
+              for path in python_path:
+                  os.environ['PATH'] = os.environ['PATH'] + os.pathsep + os.path.dirname(path)
               tb_proc = subprocess.Popen(["tensorboard", "--logdir=%s"%logdir, "--port=%d"%tb_port, "--debug"])
             tb_pid = tb_proc.pid
 

--- a/src/com/yahoo/ml/tf/TFSparkNode.py
+++ b/src/com/yahoo/ml/tf/TFSparkNode.py
@@ -316,7 +316,7 @@ def run(fn, tf_args, cluster_meta, tensorboard, queues, background):
               tb_proc = subprocess.Popen([pypath, "%s/tensorboard"%pydir, "--logdir=%s"%logdir, "--port=%d"%tb_port, "--debug"])
             else:
               # system-installed Python & tensorboard
-              python_path = os.environ['PYTHONPATH'].split(":")
+              python_path = os.environ['PYTHONPATH'].split(os.pathsep)
               for path in python_path:
                   os.environ['PATH'] = os.environ['PATH'] + os.pathsep + os.path.dirname(path)
               tb_proc = subprocess.Popen(["tensorboard", "--logdir=%s"%logdir, "--port=%d"%tb_port, "--debug"])


### PR DESCRIPTION
## What changes were proposed in this pull request?
Generally speaking we set `PYSPARK_PYTHON` to `spark-env.sh`. It means that `PYSPARK_PYTHON` may be not in `os.environ`. This PR add extra `PATH` to find `tensorboard`. more see #61.

`PYTHONPATH` may looks like this:
```
'PYTHONPATH': '/opt/cloudera/parcels/2.1.0-2.6.0.d20170113-15.36.26/lib/spark/jars/spark-core_2.11-2.2.0-SNAPSHOT.jar:/opt/cloudera/parcels/Anaconda/bin/python::/opt/cloudera/parcels/Anaconda/bin/python:/data/M05/yarn/nm/usercache/tandem/appcache/application_1491988027269_1406/container_e55_1491988027269_1406_01_000004/__pyfiles__:/opt/cloudera/parcels/2.1.0-2.6.0.d20170113-15.36.26/lib/spark/python/lib/py4j-0.10.4-src.zip:/opt/cloudera/parcels/2.1.0-2.6.0.d20170113-15.36.26/lib/spark/python/lib/pyspark.zip:/data/M05/yarn/nm/usercache/tandem/appcache/application_1491988027269_1406/container_e55_1491988027269_1406_01_000004/tfspark.zip'
```

## How was this patch tested?
manual tests

![tensorboard](https://cloud.githubusercontent.com/assets/5399861/25226939/47b7941e-25f9-11e7-9237-22cdc7d77239.jpg)
