### PR TITLE
Use IP address instead of socket hostname

### DIFF
--- a/tensorflowonspark/TFSparkNode.py
+++ b/tensorflowonspark/TFSparkNode.py
@@ -32,6 +32,7 @@ import uuid
 from . import TFManager
 from . import reservation
 from . import marker
+from . import util
 
 class TFNodeContext:
     """This encapsulates key metadata for each TF node"""
@@ -85,7 +86,7 @@ def reserve(cluster_spec, tensorboard, cluster_id, queues=['input', 'output']):
                break;
 
         # get unique id (hostname,ppid) for this executor's JVM
-        host = socket.gethostname()
+        host = util.get_ip_address()
         ppid = os.getppid()
 
         # check for existing TFManagers
@@ -177,7 +178,7 @@ def start(fn, tf_args, cluster_info, defaultFS, working_dir, background):
         # construct a TensorFlow clusterspec from supplied cluster_info AND get node info for this executor
         # Note: we could compute the clusterspec outside this function, but it's just a subset of cluster_info...
         spec = {}
-        host = socket.gethostname()
+        host = util.get_ip_address()
         ppid = os.getppid()
         job_name = ''
         task_index = -1
@@ -268,7 +269,7 @@ def run(fn, tf_args, cluster_meta, tensorboard, queues, background):
                break;
 
         # get unique id (hostname,ppid) for this executor's JVM
-        host = socket.gethostname()
+        host = util.get_ip_address()
         ppid = os.getppid()
         port = 0
 
@@ -429,7 +430,7 @@ def train(cluster_info, cluster_meta, qname='input'):
     """
     def _train(iter):
         # get shared queue, reconnecting if necessary
-        mgr = _get_manager(cluster_info, socket.gethostname(), os.getppid())
+        mgr = _get_manager(cluster_info, util.get_ip_address(), os.getppid())
         queue = mgr.get_queue(qname)
         state = str(mgr.get('state'))
         logging.info("mgr.state={0}".format(state))
@@ -473,7 +474,7 @@ def inference(cluster_info, qname='input'):
     """
     def _inference(iter):
         # get shared queue, reconnecting if necessary
-        mgr = _get_manager(cluster_info, socket.gethostname(), os.getppid())
+        mgr = _get_manager(cluster_info, util.get_ip_address(), os.getppid())
         queue_in = mgr.get_queue(qname)
 
         logging.info("Feeding partition {0} into {1} queue {2}".format(iter, qname, queue_in))
@@ -512,7 +513,7 @@ def shutdown(cluster_info, queues=['input']):
         """
         Stops all TensorFlow nodes by feeding None into the multiprocessing.Queues.
         """
-        host = socket.gethostname()
+        host = util.get_ip_address()
         ppid = os.getppid()
 
         # reconnect to shared queue

--- a/tensorflowonspark/reservation.py
+++ b/tensorflowonspark/reservation.py
@@ -14,6 +14,8 @@ import struct
 import threading
 import time
 
+from . import util
+
 BUFSIZE = 1024
 
 class Reservations:
@@ -110,7 +112,8 @@ class Server(MessageSocket):
     server_sock.bind(('',0))
     server_sock.listen(1)
 
-    host = socket.gethostname()
+    # hostname may not be resolvable but IP address probably will be
+    host = util.get_ip_address()
     port = server_sock.getsockname()[1]
     addr = (host,port)
     logging.info("listening for reservations at {0}".format(addr))
@@ -192,4 +195,3 @@ class Client(MessageSocket):
   def request_stop(self):
     resp = self._request('STOP')
     return resp
-

--- a/tensorflowonspark/util.py
+++ b/tensorflowonspark/util.py
@@ -1,0 +1,16 @@
+# Copyright 2017 Yahoo Inc.
+# Licensed under the terms of the Apache 2.0 license.
+# Please see LICENSE file in the project root for terms.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import nested_scopes
+from __future__ import print_function
+
+import socket
+
+def get_ip_address():
+  s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+  s.connect(("8.8.8.8", 80))
+  return s.getsockname()[0]
+


### PR DESCRIPTION
It is more reliable to use IP addresses to pass cluster specifications since they are more likely to be resolvable by other machines in the cluster (as opposed to socket hostnames). This PR replaces all instances of `socket.gethostname` with `util.get_ip_address`.

I have tested this with a distributed tensorflowonspark job and the job runs properly.