### PR TITLE
Cache session during pipeline inferencing

### DIFF
--- a/examples/imagenet/inception/imagenet_distributed_train_pipeline.py
+++ b/examples/imagenet/inception/imagenet_distributed_train_pipeline.py
@@ -10,7 +10,7 @@ from pyspark.context import SparkContext
 from pyspark.conf import SparkConf
 from pyspark.sql import SparkSession
 from tensorflowonspark import TFCluster, TFNode, dfutil
-from tensorflowonspark.pipeline import TFEstimator, TFModel
+from tensorflowonspark.pipeline import TFEstimator
 from datetime import datetime
 
 import inception_export

--- a/examples/imagenet/inception/imagenet_distributed_train_pipeline.py
+++ b/examples/imagenet/inception/imagenet_distributed_train_pipeline.py
@@ -82,21 +82,18 @@ if __name__ == '__main__':
 
   print("{0} ===== Start".format(datetime.now().isoformat()))
 
-#  df = dfutil.loadTFRecords(sc, args.train_data, binary_features=['image/encoded'])
-#  estimator = TFEstimator(main_fun, args, tf_argv=sys.argv, export_fn=inception_export.export) \
-#          .setModelDir(args.train_dir) \
-#          .setExportDir(args.export_dir) \
-#          .setTFRecordDir(args.tfrecord_dir) \
-#          .setClusterSize(args.cluster_size) \
-#          .setNumPS(args.num_ps) \
-#          .setInputMode(TFCluster.InputMode.TENSORFLOW) \
-#          .setTensorboard(args.tensorboard) \
-#
-#  print("{0} ===== Train".format(datetime.now().isoformat()))
-#  model = estimator.fit(df)
+  df = dfutil.loadTFRecords(sc, args.train_data, binary_features=['image/encoded'])
+  estimator = TFEstimator(main_fun, args, tf_argv=sys.argv, export_fn=inception_export.export) \
+          .setModelDir(args.train_dir) \
+          .setExportDir(args.export_dir) \
+          .setTFRecordDir(args.tfrecord_dir) \
+          .setClusterSize(args.cluster_size) \
+          .setNumPS(args.num_ps) \
+          .setInputMode(TFCluster.InputMode.TENSORFLOW) \
+          .setTensorboard(args.tensorboard) \
 
-  model = TFModel(args, tf_argv=sys.argv) \
-        .setExportDir(args.export_dir)
+  print("{0} ===== Train".format(datetime.now().isoformat()))
+  model = estimator.fit(df)
 
   print("{0} ===== Inference".format(datetime.now().isoformat()))
   df = dfutil.loadTFRecords(sc, args.validation_data, binary_features=['image/encoded'])

--- a/examples/imagenet/inception/inception_export.py
+++ b/examples/imagenet/inception/inception_export.py
@@ -103,8 +103,8 @@ def export(args):
     # exported signatures defined in code
     signatures = {
       tf.saved_model.signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY: {
-        'inputs': { 'jpegs': jpegs },
-        'outputs': { 'logits': logits },
+        'inputs': { 'jpegs': jpegs, 'labels': labels },
+        'outputs': { 'top_5_acc': top_5_op },
         'method_name': tf.saved_model.signature_constants.PREDICT_METHOD_NAME
       }
     }

--- a/tensorflowonspark/pipeline.py
+++ b/tensorflowonspark/pipeline.py
@@ -360,7 +360,7 @@ def _run_model(iterator, args):
 
   global global_sess, global_args
   if global_sess and global_args == args:
-    # if graph/session already loaded/started (and using same input/output signatures), just reuse it
+    # if graph/session already loaded/started (and using same args), just reuse it
     sess = global_sess
   else:
     # otherwise, create new session and load graph from disk

--- a/tensorflowonspark/pipeline.py
+++ b/tensorflowonspark/pipeline.py
@@ -333,8 +333,7 @@ class TFModel(Model, TFParams,
 
 # global to each python worker process on the executors
 global_sess = None
-global_input_mapping = {}
-global_output_mapping = {}
+global_args = None
 
 def _run_model(iterator, args):
   """Run single-node inferencing on a checkpoint/saved_model using input tensors obtained from a Spark partition iterator and returning output tensors."""
@@ -359,8 +358,8 @@ def _run_model(iterator, args):
 
   result = []
 
-  global global_sess, global_input_mapping, global_output_mapping
-  if global_sess and global_input_mapping == args.input_mapping and global_output_mapping == args.output_mapping:
+  global global_sess, global_args
+  if global_sess and global_args == args:
     # if graph/session already loaded/started (and using same input/output signatures), just reuse it
     sess = global_sess
   else:
@@ -382,8 +381,7 @@ def _run_model(iterator, args):
     else:
       raise Exception("Inferencing requires either --model_dir or --export_dir argument")
     global_sess = sess
-    global_input_mapping = args.input_mapping
-    global_output_mapping = args.output_mapping
+    global_args = args
 
   # get list of input/output tensors (by name)
   if args.signature_def_key:


### PR DESCRIPTION
Also, modified imagenet pipeline example to export `top_5_acc` instead of `logits`.
