### PR TITLE
TF 1.4 datasets examples

### DIFF
--- a/examples/mnist/spark/mnist_dist_dataset.py
+++ b/examples/mnist/spark/mnist_dist_dataset.py
@@ -1,0 +1,159 @@
+# Copyright 2017 Yahoo Inc.
+# Licensed under the terms of the Apache 2.0 license.
+# Please see LICENSE file in the project root for terms.
+
+# Distributed MNIST on grid based on TensorFlow MNIST example
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import nested_scopes
+from __future__ import print_function
+
+def print_log(worker_num, arg):
+  print("{0}: {1}".format(worker_num, arg))
+
+def map_fun(args, ctx):
+  from tensorflowonspark import TFNode
+  from datetime import datetime
+  import math
+  import numpy
+  import tensorflow as tf
+
+  worker_num = ctx.worker_num
+  job_name = ctx.job_name
+  task_index = ctx.task_index
+
+  # Parameters
+  IMAGE_PIXELS = 28
+  hidden_units = 128
+
+  # Get TF cluster and server instances
+  cluster, server = TFNode.start_cluster_server(ctx, 1, args.rdma)
+
+  # Create generator for Spark data feed
+  tf_feed = TFNode.DataFeed(ctx.mgr, args.mode == "train")
+
+  def rdd_generator():
+    while not tf_feed.should_stop():
+      batch = tf_feed.next_batch(1)[0]
+      image = numpy.array(batch[0])
+      image = image.astype(numpy.float32) / 255.0
+      label = numpy.array(batch[1])
+      label = label.astype(numpy.int64)
+      yield (image, label)
+
+  if job_name == "ps":
+    server.join()
+  elif job_name == "worker":
+
+    # Assigns ops to the local worker by default.
+    with tf.device(tf.train.replica_device_setter(
+        worker_device="/job:worker/task:%d" % task_index,
+        cluster=cluster)):
+
+      # Dataset for input data
+      ds = tf.data.Dataset.from_generator(rdd_generator, (tf.float32, tf.float32), (tf.TensorShape([IMAGE_PIXELS * IMAGE_PIXELS]), tf.TensorShape([10]))).batch(args.batch_size)
+      iterator = ds.make_one_shot_iterator()
+      x, y_ = iterator.get_next()
+
+      # Variables of the hidden layer
+      hid_w = tf.Variable(tf.truncated_normal([IMAGE_PIXELS * IMAGE_PIXELS, hidden_units],
+                              stddev=1.0 / IMAGE_PIXELS), name="hid_w")
+      hid_b = tf.Variable(tf.zeros([hidden_units]), name="hid_b")
+      tf.summary.histogram("hidden_weights", hid_w)
+
+      # Variables of the softmax layer
+      sm_w = tf.Variable(tf.truncated_normal([hidden_units, 10],
+                              stddev=1.0 / math.sqrt(hidden_units)), name="sm_w")
+      sm_b = tf.Variable(tf.zeros([10]), name="sm_b")
+      tf.summary.histogram("softmax_weights", sm_w)
+
+      # # Placeholders or QueueRunner/Readers for input data
+      # x = tf.placeholder(tf.float32, [None, IMAGE_PIXELS * IMAGE_PIXELS], name="x")
+      # y_ = tf.placeholder(tf.float32, [None, 10], name="y_")
+
+      x_img = tf.reshape(x, [-1, IMAGE_PIXELS, IMAGE_PIXELS, 1])
+      tf.summary.image("x_img", x_img)
+
+      hid_lin = tf.nn.xw_plus_b(x, hid_w, hid_b)
+      hid = tf.nn.relu(hid_lin)
+
+      y = tf.nn.softmax(tf.nn.xw_plus_b(hid, sm_w, sm_b))
+
+      global_step = tf.Variable(0)
+
+      loss = -tf.reduce_sum(y_ * tf.log(tf.clip_by_value(y, 1e-10, 1.0)))
+      tf.summary.scalar("loss", loss)
+
+      train_op = tf.train.AdagradOptimizer(0.01).minimize(
+          loss, global_step=global_step)
+
+      # Test trained model
+      label = tf.argmax(y_, 1, name="label")
+      prediction = tf.argmax(y, 1,name="prediction")
+      correct_prediction = tf.equal(prediction, label)
+
+      accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32), name="accuracy")
+      tf.summary.scalar("acc", accuracy)
+
+      saver = tf.train.Saver()
+      summary_op = tf.summary.merge_all()
+      init_op = tf.global_variables_initializer()
+
+    # Create a "supervisor", which oversees the training process and stores model state into HDFS
+    logdir = TFNode.hdfs_path(ctx, args.model)
+    print("tensorflow model path: {0}".format(logdir))
+    summary_writer = tf.summary.FileWriter("tensorboard_%d" % worker_num, graph=tf.get_default_graph())
+
+    if args.mode == "train":
+      sv = tf.train.Supervisor(is_chief=(task_index == 0),
+                               logdir=logdir,
+                               init_op=init_op,
+                               summary_op=None,
+                               saver=saver,
+                               global_step=global_step,
+                               stop_grace_secs=300,
+                               save_model_secs=10)
+    else:
+      sv = tf.train.Supervisor(is_chief=(task_index == 0),
+                               logdir=logdir,
+                               summary_op=None,
+                               saver=saver,
+                               global_step=global_step,
+                               stop_grace_secs=300,
+                               save_model_secs=0)
+
+    # The supervisor takes care of session initialization, restoring from
+    # a checkpoint, and closing when done or an error occurs.
+    with sv.managed_session(server.target) as sess:
+      print("{0} session ready".format(datetime.now().isoformat()))
+
+      # Loop until the supervisor shuts down or 1000000 steps have completed.
+      step = 0
+      while not sv.should_stop() and not tf_feed.should_stop() and step < args.steps:
+        # Run a training step asynchronously.
+        # See `tf.train.SyncReplicasOptimizer` for additional details on how to
+        # perform *synchronous* training.
+
+        if args.mode == "train":
+          _, summary, step = sess.run([train_op, summary_op, global_step])
+          # print accuracy and save model checkpoint to HDFS every 100 steps
+          if (step % 100 == 0):
+            print("{0} step: {1} accuracy: {2}".format(datetime.now().isoformat(), step, sess.run(accuracy)))
+
+          if sv.is_chief:
+            summary_writer.add_summary(summary, step)
+        else:  # args.mode == "inference"
+          labels, preds, acc = sess.run([label, prediction, accuracy])
+
+          results = ["{0} Label: {1}, Prediction: {2}".format(datetime.now().isoformat(), l, p) for l,p in zip(labels,preds)]
+          tf_feed.batch_results(results)
+          print("acc: {0}".format(acc))
+
+      if sv.should_stop() or step >= args.steps:
+        tf_feed.terminate()
+
+    # Ask for all the services to stop.
+    print("{0} stopping supervisor".format(datetime.now().isoformat()))
+    sv.stop()
+

--- a/examples/mnist/spark/mnist_spark_dataset.py
+++ b/examples/mnist/spark/mnist_spark_dataset.py
@@ -1,0 +1,71 @@
+# Copyright 2017 Yahoo Inc.
+# Licensed under the terms of the Apache 2.0 license.
+# Please see LICENSE file in the project root for terms.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from pyspark.context import SparkContext
+from pyspark.conf import SparkConf
+
+import argparse
+import numpy
+import tensorflow as tf
+from datetime import datetime
+
+from tensorflowonspark import TFCluster
+import mnist_dist_dataset
+
+sc = SparkContext(conf=SparkConf().setAppName("mnist_spark"))
+executors = sc._conf.get("spark.executor.instances")
+num_executors = int(executors) if executors is not None else 1
+num_ps = 1
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-b", "--batch_size", help="number of records per batch", type=int, default=100)
+parser.add_argument("-e", "--epochs", help="number of epochs", type=int, default=1)
+parser.add_argument("-f", "--format", help="example format: (csv|tfr)", choices=["csv","tfr"], default="csv")
+parser.add_argument("-i", "--images", help="HDFS path to MNIST images in parallelized format")
+parser.add_argument("-l", "--labels", help="HDFS path to MNIST labels in parallelized format")
+parser.add_argument("-m", "--model", help="HDFS path to save/load model during train/inference", default="mnist_model")
+parser.add_argument("-n", "--cluster_size", help="number of nodes in the cluster", type=int, default=num_executors)
+parser.add_argument("-o", "--output", help="HDFS path to save test/inference output", default="predictions")
+parser.add_argument("-r", "--readers", help="number of reader/enqueue threads", type=int, default=1)
+parser.add_argument("-s", "--steps", help="maximum number of steps", type=int, default=1000)
+parser.add_argument("-tb", "--tensorboard", help="launch tensorboard process", action="store_true")
+parser.add_argument("-X", "--mode", help="train|inference", default="train")
+parser.add_argument("-c", "--rdma", help="use rdma connection", default=False)
+args = parser.parse_args()
+print("args:",args)
+
+print("{0} ===== Start".format(datetime.now().isoformat()))
+
+if args.format == "tfr":
+  images = sc.newAPIHadoopFile(args.images, "org.tensorflow.hadoop.io.TFRecordFileInputFormat",
+                              keyClass="org.apache.hadoop.io.BytesWritable",
+                              valueClass="org.apache.hadoop.io.NullWritable")
+  def toNumpy(bytestr):
+    example = tf.train.Example()
+    example.ParseFromString(bytestr)
+    features = example.features.feature
+    image = numpy.array(features['image'].int64_list.value)
+    label = numpy.array(features['label'].int64_list.value)
+    return (image, label)
+  dataRDD = images.map(lambda x: toNumpy(str(x[0])))
+else:  # args.format == "csv":
+  images = sc.textFile(args.images).map(lambda ln: [int(x) for x in ln.split(',')])
+  labels = sc.textFile(args.labels).map(lambda ln: [float(x) for x in ln.split(',')])
+  print("zipping images and labels")
+  dataRDD = images.zip(labels)
+
+cluster = TFCluster.run(sc, mnist_dist_dataset.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK)
+if args.mode == "train":
+  cluster.train(dataRDD, args.epochs)
+else:
+  labelRDD = cluster.inference(dataRDD)
+  labelRDD.saveAsTextFile(args.output)
+cluster.shutdown()
+
+print("{0} ===== Stop".format(datetime.now().isoformat()))
+

--- a/examples/mnist/tf/mnist_dist_dataset.py
+++ b/examples/mnist/tf/mnist_dist_dataset.py
@@ -1,0 +1,180 @@
+# Copyright 2017 Yahoo Inc.
+# Licensed under the terms of the Apache 2.0 license.
+# Please see LICENSE file in the project root for terms.
+
+# Distributed MNIST on grid based on TensorFlow MNIST example
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+def print_log(worker_num, arg):
+  print("%d: " % worker_num, end=" ")
+  print(arg)
+
+def map_fun(args, ctx):
+  from tensorflowonspark import TFNode
+  from datetime import datetime
+  import math
+  import os
+  import tensorflow as tf
+  import time
+
+  worker_num = ctx.worker_num
+  job_name = ctx.job_name
+  task_index = ctx.task_index
+
+  # Parameters
+  IMAGE_PIXELS = 28
+  hidden_units = 128
+
+  # Get TF cluster and server instances
+  cluster, server = TFNode.start_cluster_server(ctx, 1, args.rdma)
+
+  def _parse_csv(ln):
+    splits = tf.string_split([ln], delimiter='|')
+    lbl = splits.values[0]
+    img = splits.values[1]
+    image_defaults = [ [0.0] for col in range(IMAGE_PIXELS * IMAGE_PIXELS) ]
+    image = tf.stack(tf.decode_csv(img, record_defaults=image_defaults))
+    norm = tf.constant(255, dtype=tf.float32, shape=(784,))
+    normalized_image = tf.div(image, norm)
+    label_value = tf.string_to_number(lbl, tf.int32)
+    label = tf.one_hot(label_value, 10)
+    return (normalized_image, label, label_value)
+
+  def _parse_tfr(example_proto):
+    print("example_proto: {}".format(example_proto))
+    feature_def = {"label": tf.FixedLenFeature(10, tf.int64),
+                "image": tf.FixedLenFeature(IMAGE_PIXELS * IMAGE_PIXELS, tf.int64)}
+    features = tf.parse_single_example(example_proto, feature_def)
+    norm = tf.constant(255, dtype=tf.float32, shape=(784,))
+    image = tf.div(tf.to_float(features['image']), norm)
+    label = tf.to_float(features['label'])
+    return (image, label)
+
+  if job_name == "ps":
+    server.join()
+  elif job_name == "worker":
+    # Assigns ops to the local worker by default.
+    with tf.device(tf.train.replica_device_setter(
+        worker_device="/job:worker/task:%d" % task_index,
+        cluster=cluster)):
+
+      # Dataset for input data
+      image_dir = TFNode.hdfs_path(ctx, args.images)
+      file_pattern = os.path.join(image_dir, 'part-*')
+      files = tf.gfile.Glob(file_pattern)
+
+      parse_fn = _parse_tfr if args.format == 'tfr' else _parse_csv
+      ds = tf.data.TextLineDataset(files).map(parse_fn).batch(args.batch_size)
+      iterator = ds.make_initializable_iterator()
+      x, y_, y_val = iterator.get_next()
+
+      # Variables of the hidden layer
+      hid_w = tf.Variable(tf.truncated_normal([IMAGE_PIXELS * IMAGE_PIXELS, hidden_units],
+                              stddev=1.0 / IMAGE_PIXELS), name="hid_w")
+      hid_b = tf.Variable(tf.zeros([hidden_units]), name="hid_b")
+      tf.summary.histogram("hidden_weights", hid_w)
+
+      # Variables of the softmax layer
+      sm_w = tf.Variable(tf.truncated_normal([hidden_units, 10],
+                              stddev=1.0 / math.sqrt(hidden_units)), name="sm_w")
+      sm_b = tf.Variable(tf.zeros([10]), name="sm_b")
+      tf.summary.histogram("softmax_weights", sm_w)
+
+      x_img = tf.reshape(x, [-1, IMAGE_PIXELS, IMAGE_PIXELS, 1])
+      tf.summary.image("x_img", x_img)
+
+      hid_lin = tf.nn.xw_plus_b(x, hid_w, hid_b)
+      hid = tf.nn.relu(hid_lin)
+
+      y = tf.nn.softmax(tf.nn.xw_plus_b(hid, sm_w, sm_b))
+
+      global_step = tf.Variable(0)
+
+      loss = -tf.reduce_sum(y_ * tf.log(tf.clip_by_value(y, 1e-10, 1.0)))
+      tf.summary.scalar("loss", loss)
+      train_op = tf.train.AdagradOptimizer(0.01).minimize(
+          loss, global_step=global_step)
+
+      # Test trained model
+      label = tf.argmax(y_, 1, name="label")
+      prediction = tf.argmax(y, 1, name="prediction")
+      correct_prediction = tf.equal(prediction, label)
+      accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32), name="accuracy")
+      tf.summary.scalar("acc", accuracy)
+
+      saver = tf.train.Saver()
+      summary_op = tf.summary.merge_all()
+      init_op = tf.global_variables_initializer()
+
+    # Create a "supervisor", which oversees the training process and stores model state into HDFS
+    logdir = TFNode.hdfs_path(ctx, args.model)
+    print("tensorflow model path: {0}".format(logdir))
+    summary_writer = tf.summary.FileWriter("tensorboard_%d" % worker_num, graph=tf.get_default_graph())
+
+    if args.mode == "train":
+      sv = tf.train.Supervisor(is_chief=(task_index == 0),
+                               logdir=logdir,
+                               init_op=init_op,
+                               summary_op=None,
+                               saver=saver,
+                               global_step=global_step,
+                               stop_grace_secs=300,
+                               save_model_secs=10)
+    else:
+      sv = tf.train.Supervisor(is_chief=(task_index == 0),
+                               logdir=logdir,
+                               summary_op=None,
+                               saver=saver,
+                               global_step=global_step,
+                               stop_grace_secs=300,
+                               save_model_secs=0)
+      output_dir = TFNode.hdfs_path(ctx, args.output)
+      tf.gfile.MkDir(output_dir)
+      output_file = tf.gfile.Open("{0}/part-{1:05d}".format(output_dir, worker_num), mode='w')
+
+    # The supervisor takes care of session initialization, restoring from
+    # a checkpoint, and closing when done or an error occurs.
+    with sv.managed_session(server.target) as sess:
+      print("{0} session ready".format(datetime.now().isoformat()))
+
+      # Loop until the supervisor shuts down or 1000000 steps have completed.
+      sess.run(iterator.initializer)
+      step = 0
+      count = 0
+      while not sv.should_stop() and step < args.steps:
+
+        # Run a training step asynchronously.
+        # See `tf.train.SyncReplicasOptimizer` for additional details on how to
+        # perform *synchronous* training.
+
+        # using QueueRunners/Readers
+        if args.mode == "train":
+          if (step % 100 == 0):
+            print("{0} step: {1} accuracy: {2}".format(datetime.now().isoformat(), step, sess.run(accuracy)))
+          _, summary, step, yv = sess.run([train_op, summary_op, global_step, y_val])
+          #print("yval: {}".format(yv))
+          if sv.is_chief:
+            summary_writer.add_summary(summary, step)
+        else:  # args.mode == "inference"
+          labels, pred, acc = sess.run([label, prediction, accuracy])
+          #print("label: {0}, pred: {1}".format(labels, pred))
+          print("acc: {0}".format(acc))
+          for i in range(len(labels)):
+            count += 1
+            output_file.write("{0} {1}\n".format(labels[i], pred[i]))
+          print("count: {0}".format(count))
+
+    if args.mode == "inference":
+      output_file.close()
+      # Delay chief worker from shutting down supervisor during inference, since it can load model, start session,
+      # run inference and request stop before the other workers even start/sync their sessions.
+      if task_index == 0:
+        time.sleep(60)
+
+    # Ask for all the services to stop.
+    print("{0} stopping supervisor".format(datetime.now().isoformat()))
+    sv.stop()
+

--- a/examples/mnist/tf/mnist_spark_dataset.py
+++ b/examples/mnist/tf/mnist_spark_dataset.py
@@ -1,0 +1,46 @@
+# Copyright 2017 Yahoo Inc.
+# Licensed under the terms of the Apache 2.0 license.
+# Please see LICENSE file in the project root for terms.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from pyspark.context import SparkContext
+from pyspark.conf import SparkConf
+
+import argparse
+from datetime import datetime
+
+from tensorflowonspark import TFCluster
+import mnist_dist_dataset
+
+sc = SparkContext(conf=SparkConf().setAppName("mnist_tf"))
+executors = sc._conf.get("spark.executor.instances")
+num_executors = int(executors) if executors is not None else 1
+num_ps = 1
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-b", "--batch_size", help="number of records per batch", type=int, default=100)
+parser.add_argument("-e", "--epochs", help="number of epochs", type=int, default=0)
+parser.add_argument("-f", "--format", help="example format: (csv2|tfr)", choices=["csv2","tfr"], default="tfr")
+parser.add_argument("-i", "--images", help="HDFS path to MNIST images in parallelized format")
+parser.add_argument("-l", "--labels", help="HDFS path to MNIST labels in parallelized format")
+parser.add_argument("-m", "--model", help="HDFS path to save/load model during train/test", default="mnist_model")
+parser.add_argument("-n", "--cluster_size", help="number of nodes in the cluster (for Spark Standalone)", type=int, default=num_executors)
+parser.add_argument("-o", "--output", help="HDFS path to save test/inference output", default="predictions")
+parser.add_argument("-r", "--readers", help="number of reader/enqueue threads", type=int, default=1)
+parser.add_argument("-s", "--steps", help="maximum number of steps", type=int, default=1000)
+parser.add_argument("-tb", "--tensorboard", help="launch tensorboard process", action="store_true")
+parser.add_argument("-X", "--mode", help="train|inference", default="train")
+parser.add_argument("-c", "--rdma", help="use rdma connection", default=False)
+args = parser.parse_args()
+print("args:",args)
+
+
+print("{0} ===== Start".format(datetime.now().isoformat()))
+cluster = TFCluster.run(sc, mnist_dist_dataset.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.TENSORFLOW)
+cluster.shutdown()
+
+print("{0} ===== Stop".format(datetime.now().isoformat()))
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
   name = 'tensorflowonspark',
   packages = ['tensorflowonspark'],
-  version = '1.0.6',
+  version = '1.0.7',
   description = 'Deep learning with TensorFlow on Apache Spark clusters',
   author = 'Yahoo, Inc.',
   url = 'https://github.com/yahoo/TensorFlowOnSpark',

--- a/tensorflowonspark/TFSparkNode.py
+++ b/tensorflowonspark/TFSparkNode.py
@@ -172,13 +172,13 @@ def run(fn, tf_args, cluster_meta, tensorboard, queues, background):
         pypath = os.environ['PYSPARK_PYTHON']
         logging.info("PYSPARK_PYTHON: {0}".format(pypath))
         pydir = os.path.dirname(pypath)
-        tb_proc = subprocess.Popen([pypath, "%s/tensorboard" % pydir, "--logdir=%s" % logdir, "--port=%d" % tb_port, "--debug"], env=os.environ)
+        tb_proc = subprocess.Popen([pypath, "%s/tensorboard" % pydir, "--logdir=%s" % logdir, "--port=%d" % tb_port], env=os.environ)
       else:
         # system-installed Python & tensorboard
         python_path = os.environ['PYTHONPATH'].split(os.pathsep)
         for path in python_path:
             os.environ['PATH'] = os.environ['PATH'] + os.pathsep + os.path.dirname(path)
-        tb_proc = subprocess.Popen(["tensorboard", "--logdir=%s" % logdir, "--port=%d" % tb_port, "--debug"], env=os.environ)
+        tb_proc = subprocess.Popen(["tensorboard", "--logdir=%s" % logdir, "--port=%d" % tb_port], env=os.environ)
       tb_pid = tb_proc.pid
 
     # check server to see if this task is being retried (i.e. already reserved)

--- a/tensorflowonspark/TFSparkNode.py
+++ b/tensorflowonspark/TFSparkNode.py
@@ -13,6 +13,7 @@ import os
 import platform
 import socket
 import subprocess
+import sys
 import multiprocessing
 import uuid
 from . import TFManager
@@ -167,18 +168,16 @@ def run(fn, tf_args, cluster_meta, tensorboard, queues, background):
       tb_sock.close()
       logdir = "tensorboard_%d" % worker_num
 
-      if 'PYSPARK_PYTHON' in os.environ:
-        # user-specified Python (typically Python.zip)
-        pypath = os.environ['PYSPARK_PYTHON']
-        logging.info("PYSPARK_PYTHON: {0}".format(pypath))
-        pydir = os.path.dirname(pypath)
-        tb_proc = subprocess.Popen([pypath, "%s/tensorboard" % pydir, "--logdir=%s" % logdir, "--port=%d" % tb_port], env=os.environ)
-      else:
-        # system-installed Python & tensorboard
-        python_path = os.environ['PYTHONPATH'].split(os.pathsep)
-        for path in python_path:
-            os.environ['PATH'] = os.environ['PATH'] + os.pathsep + os.path.dirname(path)
-        tb_proc = subprocess.Popen(["tensorboard", "--logdir=%s" % logdir, "--port=%d" % tb_port], env=os.environ)
+      # search for tensorboard in python/bin, PATH, and PYTHONPATH
+      pypath = sys.executable
+      pydir = os.path.dirname(pypath)
+      search_path = os.pathsep.join([pydir, os.environ['PATH'], os.environ['PYTHONPATH']])
+      tb_path = util.find_in_path(search_path, 'tensorboard')
+      if not tb_path:
+        raise Exception("Unable to find 'tensorboard' in: {}".format(search_path))
+
+      # launch tensorboard
+      tb_proc = subprocess.Popen([pypath, tb_path, "--logdir=%s" % logdir, "--port=%d" % tb_port], env=os.environ)
       tb_pid = tb_proc.pid
 
     # check server to see if this task is being retried (i.e. already reserved)

--- a/tensorflowonspark/util.py
+++ b/tensorflowonspark/util.py
@@ -7,11 +7,20 @@ from __future__ import division
 from __future__ import nested_scopes
 from __future__ import print_function
 
+import os
 import socket
 
 def get_ip_address():
-  """Simple utility to get host IP address"""
+  """Simple utility to get host IP address."""
   s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
   s.connect(("8.8.8.8", 80))
   return s.getsockname()[0]
 
+
+def find_in_path(path, file):
+  """Find a file in a given path string."""
+  for p in path.split(os.pathsep):
+    candidate = os.path.join(p, file)
+    if (os.path.exists(os.path.join(p, file))):
+      return candidate
+  return False


### PR DESCRIPTION
- MNIST examples for InputMode.SPARK and InputMode.TENSORFLOW using TFRecords and CSV.
- Removes `--debug` flag from tensorboard (which conflicts with a new flag in 1.4).
- Added utility to look for tensorboard binary in multiple paths.