### PR TITLE
TFNode refactor

### DIFF
--- a/examples/imagenet/inception/imagenet_distributed_train_pipeline.py
+++ b/examples/imagenet/inception/imagenet_distributed_train_pipeline.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
   print("{0} ===== Start".format(datetime.now().isoformat()))
 
   df = dfutil.loadTFRecords(sc, args.train_data, binary_features=['image/encoded'])
-  estimator = TFEstimator(main_fun, args, tf_argv=sys.argv, export_fn=inception_export.export) \
+  estimator = TFEstimator(main_fun, sys.argv, export_fn=inception_export.export) \
           .setModelDir(args.train_dir) \
           .setExportDir(args.export_dir) \
           .setTFRecordDir(args.tfrecord_dir) \

--- a/examples/mnist/spark/mnist_dist.py
+++ b/examples/mnist/spark/mnist_dist.py
@@ -33,10 +33,7 @@ def map_fun(args, ctx):
   batch_size   = args.batch_size
 
   # Get TF cluster and server instances
-  if args.start_server:
-    cluster, server = ctx.cluster, ctx.server
-  else:
-    cluster, server = ctx.start_cluster_server(1, args.rdma)
+  cluster, server = ctx.start_cluster_server(1, args.rdma)
 
   def feed_dict(batch):
     # Convert from [(images, labels)] to two numpy arrays of the proper type

--- a/examples/mnist/spark/mnist_dist.py
+++ b/examples/mnist/spark/mnist_dist.py
@@ -24,13 +24,12 @@ def map_fun(args, ctx):
   task_index = ctx.task_index
   cluster_spec = ctx.cluster_spec
 
-  IMAGE_PIXELS=28
-
   # Delay PS nodes a bit, since workers seem to reserve GPUs more quickly/reliably (w/o conflict)
   if job_name == "ps":
     time.sleep((worker_num + 1) * 5)
 
   # Parameters
+  IMAGE_PIXELS = 28
   hidden_units = 128
   batch_size   = args.batch_size
 
@@ -46,7 +45,7 @@ def map_fun(args, ctx):
       labels.append(item[1])
     xs = numpy.array(images)
     xs = xs.astype(numpy.float32)
-    xs = xs/255.0
+    xs = xs / 255.0
     ys = numpy.array(labels)
     ys = ys.astype(numpy.uint8)
     return (xs, ys)
@@ -156,7 +155,7 @@ def map_fun(args, ctx):
 
             if sv.is_chief:
               summary_writer.add_summary(summary, step)
-          else: # args.mode == "inference"
+          else:  # args.mode == "inference"
             labels, preds, acc = sess.run([label, prediction, accuracy], feed_dict=feed)
 
             results = ["{0} Label: {1}, Prediction: {2}".format(datetime.now().isoformat(), l, p) for l,p in zip(labels,preds)]

--- a/examples/mnist/spark/mnist_dist.py
+++ b/examples/mnist/spark/mnist_dist.py
@@ -22,7 +22,6 @@ def map_fun(args, ctx):
   worker_num = ctx.worker_num
   job_name = ctx.job_name
   task_index = ctx.task_index
-  cluster_spec = ctx.cluster_spec
 
   # Delay PS nodes a bit, since workers seem to reserve GPUs more quickly/reliably (w/o conflict)
   if job_name == "ps":
@@ -34,7 +33,10 @@ def map_fun(args, ctx):
   batch_size   = args.batch_size
 
   # Get TF cluster and server instances
-  cluster, server = ctx.start_cluster_server(1, args.rdma)
+  if args.start_server:
+    cluster, server = ctx.cluster, ctx.server
+  else:
+    cluster, server = ctx.start_cluster_server(1, args.rdma)
 
   def feed_dict(batch):
     # Convert from [(images, labels)] to two numpy arrays of the proper type

--- a/examples/mnist/spark/mnist_dist.py
+++ b/examples/mnist/spark/mnist_dist.py
@@ -13,7 +13,6 @@ def print_log(worker_num, arg):
   print("{0}: {1}".format(worker_num, arg))
 
 def map_fun(args, ctx):
-  from tensorflowonspark import TFNode
   from datetime import datetime
   import math
   import numpy
@@ -36,7 +35,7 @@ def map_fun(args, ctx):
   batch_size   = args.batch_size
 
   # Get TF cluster and server instances
-  cluster, server = TFNode.start_cluster_server(ctx, 1, args.rdma)
+  cluster, server = ctx.start_cluster_server(1, args.rdma)
 
   def feed_dict(batch):
     # Convert from [(images, labels)] to two numpy arrays of the proper type
@@ -106,7 +105,7 @@ def map_fun(args, ctx):
       init_op = tf.global_variables_initializer()
 
     # Create a "supervisor", which oversees the training process and stores model state into HDFS
-    logdir = TFNode.hdfs_path(ctx, args.model)
+    logdir = ctx.absolute_path(args.model)
     print("tensorflow model path: {0}".format(logdir))
 
     if job_name == "worker" and task_index == 0:
@@ -138,7 +137,7 @@ def map_fun(args, ctx):
 
       # Loop until the supervisor shuts down or 1000000 steps have completed.
       step = 0
-      tf_feed = TFNode.DataFeed(ctx.mgr, args.mode == "train")
+      tf_feed = ctx.get_data_feed(args.mode == "train")
       while not sv.should_stop() and not tf_feed.should_stop() and step < args.steps:
         # Run a training step asynchronously.
         # See `tf.train.SyncReplicasOptimizer` for additional details on how to

--- a/examples/mnist/spark/mnist_spark.py
+++ b/examples/mnist/spark/mnist_spark.py
@@ -23,19 +23,20 @@ num_executors = int(executors) if executors is not None else 1
 num_ps = 1
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-b", "--batch_size", help="number of records per batch", type=int, default=100)
-parser.add_argument("-e", "--epochs", help="number of epochs", type=int, default=1)
-parser.add_argument("-f", "--format", help="example format: (csv|pickle|tfr)", choices=["csv","pickle","tfr"], default="csv")
-parser.add_argument("-i", "--images", help="HDFS path to MNIST images in parallelized format")
-parser.add_argument("-l", "--labels", help="HDFS path to MNIST labels in parallelized format")
-parser.add_argument("-m", "--model", help="HDFS path to save/load model during train/inference", default="mnist_model")
-parser.add_argument("-n", "--cluster_size", help="number of nodes in the cluster", type=int, default=num_executors)
-parser.add_argument("-o", "--output", help="HDFS path to save test/inference output", default="predictions")
-parser.add_argument("-r", "--readers", help="number of reader/enqueue threads", type=int, default=1)
-parser.add_argument("-s", "--steps", help="maximum number of steps", type=int, default=1000)
-parser.add_argument("-tb", "--tensorboard", help="launch tensorboard process", action="store_true")
-parser.add_argument("-X", "--mode", help="train|inference", default="train")
-parser.add_argument("-c", "--rdma", help="use rdma connection", default=False)
+parser.add_argument("--batch_size", help="number of records per batch", type=int, default=100)
+parser.add_argument("--epochs", help="number of epochs", type=int, default=1)
+parser.add_argument("--format", help="example format: (csv|pickle|tfr)", choices=["csv","pickle","tfr"], default="csv")
+parser.add_argument("--images", help="HDFS path to MNIST images in parallelized format")
+parser.add_argument("--labels", help="HDFS path to MNIST labels in parallelized format")
+parser.add_argument("--model", help="HDFS path to save/load model during train/inference", default="mnist_model")
+parser.add_argument("--cluster_size", help="number of nodes in the cluster", type=int, default=num_executors)
+parser.add_argument("--output", help="HDFS path to save test/inference output", default="predictions")
+parser.add_argument("--readers", help="number of reader/enqueue threads", type=int, default=1)
+parser.add_argument("--start_server", help="start tensorflow server prior to invoking map_fun", action="store_true")
+parser.add_argument("--steps", help="maximum number of steps", type=int, default=1000)
+parser.add_argument("--tensorboard", help="launch tensorboard process", action="store_true")
+parser.add_argument("--mode", help="train|inference", default="train")
+parser.add_argument("--rdma", help="use rdma connection", default=False)
 args = parser.parse_args()
 print("args:",args)
 
@@ -63,7 +64,9 @@ else:
   print("zipping images and labels")
   dataRDD = images.zip(labels)
 
-cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK, log_dir=args.model)
+cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK,
+                        log_dir=args.model,
+                        start_server=args.start_server)
 if args.mode == "train":
   cluster.train(dataRDD, args.epochs)
 else:

--- a/examples/mnist/spark/mnist_spark.py
+++ b/examples/mnist/spark/mnist_spark.py
@@ -32,7 +32,6 @@ parser.add_argument("--model", help="HDFS path to save/load model during train/i
 parser.add_argument("--cluster_size", help="number of nodes in the cluster", type=int, default=num_executors)
 parser.add_argument("--output", help="HDFS path to save test/inference output", default="predictions")
 parser.add_argument("--readers", help="number of reader/enqueue threads", type=int, default=1)
-parser.add_argument("--start_server", help="start tensorflow server prior to invoking map_fun", action="store_true")
 parser.add_argument("--steps", help="maximum number of steps", type=int, default=1000)
 parser.add_argument("--tensorboard", help="launch tensorboard process", action="store_true")
 parser.add_argument("--mode", help="train|inference", default="train")
@@ -64,9 +63,7 @@ else:
   print("zipping images and labels")
   dataRDD = images.zip(labels)
 
-cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK,
-                        log_dir=args.model,
-                        start_server=args.start_server)
+cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK, log_dir=args.model)
 if args.mode == "train":
   cluster.train(dataRDD, args.epochs)
 else:

--- a/examples/mnist/spark/mnist_spark.py
+++ b/examples/mnist/spark/mnist_spark.py
@@ -10,12 +10,8 @@ from pyspark.context import SparkContext
 from pyspark.conf import SparkConf
 
 import argparse
-import os
 import numpy
-import sys
 import tensorflow as tf
-import threading
-import time
 from datetime import datetime
 
 from tensorflowonspark import TFCluster
@@ -61,7 +57,7 @@ else:
   if args.format == "csv":
     images = sc.textFile(args.images).map(lambda ln: [int(x) for x in ln.split(',')])
     labels = sc.textFile(args.labels).map(lambda ln: [float(x) for x in ln.split(',')])
-  else: # args.format == "pickle":
+  else:  # args.format == "pickle":
     images = sc.pickleFile(args.images)
     labels = sc.pickleFile(args.labels)
   print("zipping images and labels")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
   name = 'tensorflowonspark',
   packages = ['tensorflowonspark'],
-  version = '1.0.8',
+  version = '1.0.9',
   description = 'Deep learning with TensorFlow on Apache Spark clusters',
   author = 'Yahoo, Inc.',
   url = 'https://github.com/yahoo/TensorFlowOnSpark',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
   name = 'tensorflowonspark',
   packages = ['tensorflowonspark'],
-  version = '1.0.9',
+  version = '1.1.0',
   description = 'Deep learning with TensorFlow on Apache Spark clusters',
   author = 'Yahoo, Inc.',
   url = 'https://github.com/yahoo/TensorFlowOnSpark',

--- a/tensorflowonspark/TFCluster.py
+++ b/tensorflowonspark/TFCluster.py
@@ -186,7 +186,7 @@ class TFCluster(object):
         tb_url = "http://{0}:{1}".format(node['host'], node['tb_port'])
     return tb_url
 
-def run(sc, map_fun, tf_args, num_executors, num_ps, tensorboard=False, input_mode=InputMode.TENSORFLOW, log_dir=None, queues=['input', 'output'], start_server=False, num_gpus=1, use_rdma=False):
+def run(sc, map_fun, tf_args, num_executors, num_ps, tensorboard=False, input_mode=InputMode.TENSORFLOW, log_dir=None, queues=['input', 'output']):
   """Starts the TensorFlowOnSpark cluster and Runs the TensorFlow "main" function on the Spark executors
 
   Args:
@@ -199,9 +199,6 @@ def run(sc, map_fun, tf_args, num_executors, num_ps, tensorboard=False, input_mo
     :input_mode: TFCluster.InputMode
     :log_dir: directory to save tensorboard event logs.  If None, defaults to a fixed path on local filesystem.
     :queues: *INTERNAL_USE*
-    :start_server: start ``tf.train.Server`` prior to invoking ``map_fun``.
-    :num_gpus: number of GPUs to allocate, only used if ``start_server == True``.
-    :use_rdma: enable RDMA instead of GRPC, only used if ``start_server == True``.
 
   Returns:
     A TFCluster object representing the started cluster.
@@ -239,8 +236,6 @@ def run(sc, map_fun, tf_args, num_executors, num_ps, tensorboard=False, input_mo
   }
   nodeRDD = sc.parallelize(range(num_executors), num_executors)
 
-  logging.info("===== TFCluster.start_server: {}".format(start_server))
-
   # start TF on a background thread (on Spark driver) to allow for feeding job
   def _start():
     nodeRDD.foreachPartition(TFSparkNode.run(map_fun,
@@ -249,10 +244,7 @@ def run(sc, map_fun, tf_args, num_executors, num_ps, tensorboard=False, input_mo
                                               tensorboard,
                                               log_dir,
                                               queues,
-                                              (input_mode == InputMode.SPARK),
-                                              start_server,
-                                              num_gpus,
-                                              use_rdma))
+                                              (input_mode == InputMode.SPARK)))
   t = threading.Thread(target=_start)
   t.start()
 

--- a/tensorflowonspark/TFSparkNode.py
+++ b/tensorflowonspark/TFSparkNode.py
@@ -26,7 +26,7 @@ from . import marker
 from . import util
 
 class TFNodeContext:
-  """Struct to encapsulate unique metadata for a TensorFlowOnSpark node/executor.
+  """Encapsulates unique metadata for a TensorFlowOnSpark node/executor and provides methods to interact with Spark and HDFS.
 
   An instance of this object will be passed to the TensorFlow "main" function via the `ctx` argument.
 

--- a/tensorflowonspark/TFSparkNode.py
+++ b/tensorflowonspark/TFSparkNode.py
@@ -8,14 +8,18 @@ from __future__ import division
 from __future__ import nested_scopes
 from __future__ import print_function
 
+import getpass
 import logging
 import os
+import sys
 import platform
 import socket
+import time
 import subprocess
-import sys
 import multiprocessing
 import uuid
+from six.moves.queue import Empty
+
 from . import TFManager
 from . import reservation
 from . import marker
@@ -43,6 +47,252 @@ class TFNodeContext:
     self.defaultFS = defaultFS
     self.working_dir = working_dir
     self.mgr = mgr
+
+  def absolute_path(self, path):
+    """Convenience function to create a Tensorflow-compatible absolute path from relative paths depending on the host filesystem.
+
+    Args:
+      :path: path to convert
+
+    Returns:
+      An absolute path prefixed with the correct filesystem scheme.
+    """
+    if path.startswith("hdfs://") or path.startswith("viewfs://") or path.startswith("file://"):
+      # absolute path w/ scheme, just return as-is
+      return path
+    elif path.startswith("/"):
+      # absolute path w/o scheme, just prepend w/ defaultFS
+      return self.defaultFS + path
+    else:
+      # relative path, prepend defaultSF + standard working dir
+      if self.defaultFS.startswith("hdfs://") or self.defaultFS.startswith("viewfs://"):
+        return "{0}/user/{1}/{2}".format(self.defaultFS, getpass.getuser(), path)
+      elif self.defaultFS.startswith("file://"):
+        return "{0}/{1}/{2}".format(self.defaultFS, self.working_dir[1:], path)
+      else:
+        logging.warn("Unknown scheme {0} with relative path: {1}".format(self.defaultFS, path))
+        return "{0}/{1}".format(self.defaultFS, path)
+
+  def start_cluster_server(self, num_gpus=1, rdma=False):
+    """Function that wraps the creation of TensorFlow ``tf.train.Server`` for a node in a distributed TensorFlow cluster.
+
+    This is intended to be invoked from within the TF ``map_fun``, replacing explicit code to instantiate ``tf.train.ClusterSpec``
+    and ``tf.train.Server`` objects.
+
+    Args:
+      :num_gpu: number of GPUs desired
+      :rdma: boolean indicating if RDMA 'iverbs' should be used for cluster communications.
+
+    Returns:
+      A tuple of (cluster_spec, server)
+    """
+    import tensorflow as tf
+    from . import gpu_info
+
+    logging.info("{0}: ======== {1}:{2} ========".format(self.worker_num, self.job_name, self.task_index))
+    cluster_spec = self.cluster_spec
+    logging.info("{0}: Cluster spec: {1}".format(self.worker_num, cluster_spec))
+
+    if tf.test.is_built_with_cuda():
+      # GPU
+      gpu_initialized = False
+      while not gpu_initialized:
+        try:
+          # override PS jobs to only reserve one GPU
+          if self.job_name == 'ps':
+            num_gpus = 1
+
+          # Find a free gpu(s) to use
+          gpus_to_use = gpu_info.get_gpus(num_gpus)
+          gpu_prompt = "GPU" if num_gpus == 1 else "GPUs"
+          logging.info("{0}: Using {1}: {2}".format(self.worker_num, gpu_prompt, gpus_to_use))
+
+          # Set GPU device to use for TensorFlow
+          os.environ['CUDA_VISIBLE_DEVICES'] = gpus_to_use
+
+          # Create a cluster from the parameter server and worker hosts.
+          cluster = tf.train.ClusterSpec(cluster_spec)
+
+          # Create and start a server for the local task.
+          if rdma:
+            server = tf.train.Server(cluster, self.job_name, self.task_index, protocol="grpc+verbs")
+          else:
+            server = tf.train.Server(cluster, self.job_name, self.task_index)
+          gpu_initialized = True
+        except Exception as e:
+          print(e)
+          logging.error("{0}: Failed to allocate GPU, trying again...".format(self.worker_num))
+          time.sleep(10)
+    else:
+      # CPU
+      os.environ['CUDA_VISIBLE_DEVICES'] = ''
+      logging.info("{0}: Using CPU".format(self.worker_num))
+
+      # Create a cluster from the parameter server and worker hosts.
+      cluster = tf.train.ClusterSpec(cluster_spec)
+
+      # Create and start a server for the local task.
+      server = tf.train.Server(cluster, self.job_name, self.task_index)
+
+    return (cluster, server)
+
+  def export_saved_model(self, sess, export_dir, tag_set, signatures):
+    """Convenience function to export a saved_model using provided arguments
+
+    The caller specifies the saved_model signatures in a simplified python dictionary form, as follows::
+
+      signatures = {
+        'signature_def_key': {
+          'inputs': { 'input_tensor_alias': input_tensor_name },
+          'outputs': { 'output_tensor_alias': output_tensor_name },
+          'method_name': 'method'
+        }
+      }
+
+    And this function will generate the `signature_def_map` and export the saved_model.
+
+    Args:
+      :sess: a tf.Session instance
+      :export_dir: path to save exported saved_model
+      :tag_set: string tag_set to identify the exported graph
+      :signatures: simplified dictionary representation of a TensorFlow signature_def_map
+
+    Returns:
+      A saved_model exported to disk at ``export_dir``.
+    """
+    import tensorflow as tf
+    g = sess.graph
+    g._unsafe_unfinalize()           # https://github.com/tensorflow/serving/issues/363
+    builder = tf.saved_model.builder.SavedModelBuilder(export_dir)
+
+    logging.info("===== signatures: {}".format(signatures))
+    signature_def_map = {}
+    for key, sig in signatures.items():
+      signature_def_map[key] = tf.saved_model.signature_def_utils.build_signature_def(
+                inputs={ name:tf.saved_model.utils.build_tensor_info(tensor) for name, tensor in sig['inputs'].items() },
+                outputs={ name:tf.saved_model.utils.build_tensor_info(tensor) for name, tensor in sig['outputs'].items() },
+                method_name=sig['method_name'] if 'method_name' in sig else key)
+    logging.info("===== signature_def_map: {}".format(signature_def_map))
+    builder.add_meta_graph_and_variables(sess,
+                tag_set.split(','),
+                signature_def_map=signature_def_map,
+                clear_devices=True)
+    g.finalize()
+    builder.save()
+
+  def get_data_feed(self, train_mode=True, qname_in='input', qname_out='output', input_mapping=None):
+    return DataFeed(self.mgr, train_mode, qname_in, qname_out, input_mapping)
+
+
+class DataFeed(object):
+  """This class manages the *InputMode.SPARK* data feeding process from the perspective of the TensorFlow application.
+
+  Args:
+    :mgr: TFManager instance associated with this Python worker process.
+    :train_mode: boolean indicating if the data feed is expecting an output response (e.g. inferencing).
+    :qname_in: *INTERNAL_USE*
+    :qname_out: *INTERNAL_USE*
+    :input_mapping: *For Spark ML Pipelines only*.  Dictionary of input DataFrame columns to input TensorFlow tensors.
+  """
+  def __init__(self, mgr, train_mode=True, qname_in='input', qname_out='output', input_mapping=None):
+
+    self.mgr = mgr
+    self.train_mode = train_mode
+    self.qname_in = qname_in
+    self.qname_out = qname_out
+    self.done_feeding = False
+    self.input_tensors = [ tensor for col, tensor in sorted(input_mapping.items()) ] if input_mapping is not None else None
+
+  def next_batch(self, batch_size):
+    """Gets a batch of items from the input RDD.
+
+    If multiple tensors are provided per row in the input RDD, e.g. tuple of (tensor1, tensor2, ..., tensorN) and:
+
+    * no ``input_mapping`` was provided to the DataFeed constructor, this will return an array of ``batch_size`` tuples,
+      and the caller is responsible for separating the tensors.
+    * an ``input_mapping`` was provided to the DataFeed constructor, this will return a dictionary of N tensors,
+      with tensor names as keys and arrays of length ``batch_size`` as values.
+
+    Note: if the end of the data is reached, this may return with fewer than ``batch_size`` items.
+
+    Args:
+      :batch_size: number of items to retrieve.
+
+    Returns:
+      A batch of items or a dictionary of tensors.
+    """
+    logging.debug("next_batch() invoked")
+    queue = self.mgr.get_queue(self.qname_in)
+    tensors = [] if self.input_tensors is None else { tensor:[] for tensor in self.input_tensors }
+    count = 0
+    while count < batch_size:
+      item = queue.get(block=True)
+      if item is None:
+        # End of Feed
+        logging.info("next_batch() got None")
+        queue.task_done()
+        self.done_feeding = True
+        break
+      elif type(item) is marker.EndPartition:
+        # End of Partition
+        logging.info("next_batch() got EndPartition")
+        queue.task_done()
+        if not self.train_mode and count > 0:
+          break
+      else:
+        # Normal item
+        if self.input_tensors is None:
+          tensors.append(item)
+        else:
+          for i in range(len(self.input_tensors)):
+            tensors[self.input_tensors[i]].append(item[i])
+        count += 1
+        queue.task_done()
+    logging.debug("next_batch() returning {0} items".format(count))
+    return tensors
+
+  def should_stop(self):
+    """Check if the feed process was told to stop (by a call to ``terminate``)."""
+    return self.done_feeding
+
+  def batch_results(self, results):
+    """Push a batch of output results to the Spark output RDD of ``TFCluster.inference()``.
+
+    Note: this currently expects a one-to-one mapping of input to output data, so the length of the ``results`` array should match the length of
+    the previously retrieved batch of input data.
+
+    Args:
+      :results: array of output data for the equivalent batch of input data.
+    """
+    logging.debug("batch_results() invoked")
+    queue = self.mgr.get_queue(self.qname_out)
+    for item in results:
+      queue.put(item, block=True)
+    logging.debug("batch_results() returning data")
+
+  def terminate(self):
+    """Terminate data feeding early.
+
+    Since TensorFlow applications can often terminate on conditions unrelated to the training data (e.g. steps, accuracy, etc),
+    this method signals the data feeding process to ignore any further incoming data.  Note that Spark itself does not have a mechanism
+    to terminate an RDD operation early, so the extra partitions will still be sent to the executors (but will be ignored).  Because
+    of this, you should size your input data accordingly to avoid excessive overhead.
+    """
+    logging.info("terminate() invoked")
+    self.mgr.set('state', 'terminating')
+
+    # drop remaining items in the queue
+    queue = self.mgr.get_queue(self.qname_in)
+    count = 0
+    done = False
+    while not done:
+      try:
+        queue.get(block=True, timeout=5)
+        queue.task_done()
+        count += 1
+      except Empty:
+        logging.info("dropped {0} items from queue".format(count))
+        done = True
 
 class TFSparkNode(object):
   """Low-level functions used by the high-level TFCluster APIs to manage cluster state.

--- a/tensorflowonspark/TFSparkNode.py
+++ b/tensorflowonspark/TFSparkNode.py
@@ -330,7 +330,7 @@ def _get_manager(cluster_info, host, ppid):
   logging.info("Connected to TFSparkNode.mgr on {0}, ppid={1}, state={2}".format(host, ppid, str(TFSparkNode.mgr.get('state'))))
   return TFSparkNode.mgr
 
-def run(fn, tf_args, cluster_meta, tensorboard, log_dir, queues, background, start_server=False, num_gpus=1, use_rdma=False):
+def run(fn, tf_args, cluster_meta, tensorboard, log_dir, queues, background):
   """Wraps the user-provided TensorFlow main function in a Spark mapPartitions function.
 
   Args:
@@ -341,9 +341,6 @@ def run(fn, tf_args, cluster_meta, tensorboard, log_dir, queues, background, sta
     :log_dir: directory to save tensorboard event logs.  If None, defaults to a fixed path on local filesystem.
     :queues: *INTERNAL_USE*
     :background: boolean indicating if the TensorFlow "main" function should be run in a background process.
-    :start_server: start ``tf.train.Server`` prior to invoking ``map_fun``.
-    :num_gpus: number of GPUs to allocate, only used if ``start_server == True``.
-    :use_rdma: enable RDMA instead of GRPC, only used if ``start_server == True``.
 
   Returns:
     A nodeRDD.mapPartitions() function.
@@ -499,10 +496,6 @@ def run(fn, tf_args, cluster_meta, tensorboard, log_dir, queues, background, sta
       """Wrapper function that sets the sys.argv of the executor and starts the tf.train.server."""
       if isinstance(args, list):
         sys.argv = args
-      if start_server:
-        cluster, server = context.start_cluster_server(num_gpus, use_rdma)
-        context.cluster = cluster
-        context.server = server
       fn(args, context)
 
     if job_name == 'ps' or background:

--- a/tensorflowonspark/TFSparkNode.py
+++ b/tensorflowonspark/TFSparkNode.py
@@ -21,6 +21,7 @@ import uuid
 from six.moves.queue import Empty
 
 from . import TFManager
+from . import TFNode
 from . import reservation
 from . import marker
 from . import util
@@ -29,6 +30,7 @@ class TFNodeContext:
   """Encapsulates unique metadata for a TensorFlowOnSpark node/executor and provides methods to interact with Spark and HDFS.
 
   An instance of this object will be passed to the TensorFlow "main" function via the `ctx` argument.
+  To simply the end-user API, this class now mirrors the functions of the TFNode module.
 
   Args:
     :worker_num: integer identifier for this executor, per ``nodeRDD = sc.parallelize(range(num_executors), num_executors).``
@@ -49,250 +51,21 @@ class TFNodeContext:
     self.mgr = mgr
 
   def absolute_path(self, path):
-    """Convenience function to create a Tensorflow-compatible absolute path from relative paths depending on the host filesystem.
-
-    Args:
-      :path: path to convert
-
-    Returns:
-      An absolute path prefixed with the correct filesystem scheme.
-    """
-    if path.startswith("hdfs://") or path.startswith("viewfs://") or path.startswith("file://"):
-      # absolute path w/ scheme, just return as-is
-      return path
-    elif path.startswith("/"):
-      # absolute path w/o scheme, just prepend w/ defaultFS
-      return self.defaultFS + path
-    else:
-      # relative path, prepend defaultSF + standard working dir
-      if self.defaultFS.startswith("hdfs://") or self.defaultFS.startswith("viewfs://"):
-        return "{0}/user/{1}/{2}".format(self.defaultFS, getpass.getuser(), path)
-      elif self.defaultFS.startswith("file://"):
-        return "{0}/{1}/{2}".format(self.defaultFS, self.working_dir[1:], path)
-      else:
-        logging.warn("Unknown scheme {0} with relative path: {1}".format(self.defaultFS, path))
-        return "{0}/{1}".format(self.defaultFS, path)
+    """Convenience function to access ``TFNode.hdfs_path`` directly from this object instance."""
+    return TFNode.hdfs_path(self, path)
 
   def start_cluster_server(self, num_gpus=1, rdma=False):
-    """Function that wraps the creation of TensorFlow ``tf.train.Server`` for a node in a distributed TensorFlow cluster.
-
-    This is intended to be invoked from within the TF ``map_fun``, replacing explicit code to instantiate ``tf.train.ClusterSpec``
-    and ``tf.train.Server`` objects.
-
-    Args:
-      :num_gpu: number of GPUs desired
-      :rdma: boolean indicating if RDMA 'iverbs' should be used for cluster communications.
-
-    Returns:
-      A tuple of (cluster_spec, server)
-    """
-    import tensorflow as tf
-    from . import gpu_info
-
-    logging.info("{0}: ======== {1}:{2} ========".format(self.worker_num, self.job_name, self.task_index))
-    cluster_spec = self.cluster_spec
-    logging.info("{0}: Cluster spec: {1}".format(self.worker_num, cluster_spec))
-
-    if tf.test.is_built_with_cuda():
-      # GPU
-      gpu_initialized = False
-      while not gpu_initialized:
-        try:
-          # override PS jobs to only reserve one GPU
-          if self.job_name == 'ps':
-            num_gpus = 1
-
-          # Find a free gpu(s) to use
-          gpus_to_use = gpu_info.get_gpus(num_gpus)
-          gpu_prompt = "GPU" if num_gpus == 1 else "GPUs"
-          logging.info("{0}: Using {1}: {2}".format(self.worker_num, gpu_prompt, gpus_to_use))
-
-          # Set GPU device to use for TensorFlow
-          os.environ['CUDA_VISIBLE_DEVICES'] = gpus_to_use
-
-          # Create a cluster from the parameter server and worker hosts.
-          cluster = tf.train.ClusterSpec(cluster_spec)
-
-          # Create and start a server for the local task.
-          if rdma:
-            server = tf.train.Server(cluster, self.job_name, self.task_index, protocol="grpc+verbs")
-          else:
-            server = tf.train.Server(cluster, self.job_name, self.task_index)
-          gpu_initialized = True
-        except Exception as e:
-          print(e)
-          logging.error("{0}: Failed to allocate GPU, trying again...".format(self.worker_num))
-          time.sleep(10)
-    else:
-      # CPU
-      os.environ['CUDA_VISIBLE_DEVICES'] = ''
-      logging.info("{0}: Using CPU".format(self.worker_num))
-
-      # Create a cluster from the parameter server and worker hosts.
-      cluster = tf.train.ClusterSpec(cluster_spec)
-
-      # Create and start a server for the local task.
-      server = tf.train.Server(cluster, self.job_name, self.task_index)
-
-    return (cluster, server)
+    """Convenience function to access ``TFNode.start_cluster_server`` directly from this object instance."""
+    return TFNode.start_cluster_server(self, num_gpus, rdma)
 
   def export_saved_model(self, sess, export_dir, tag_set, signatures):
-    """Convenience function to export a saved_model using provided arguments
-
-    The caller specifies the saved_model signatures in a simplified python dictionary form, as follows::
-
-      signatures = {
-        'signature_def_key': {
-          'inputs': { 'input_tensor_alias': input_tensor_name },
-          'outputs': { 'output_tensor_alias': output_tensor_name },
-          'method_name': 'method'
-        }
-      }
-
-    And this function will generate the `signature_def_map` and export the saved_model.
-
-    Args:
-      :sess: a tf.Session instance
-      :export_dir: path to save exported saved_model
-      :tag_set: string tag_set to identify the exported graph
-      :signatures: simplified dictionary representation of a TensorFlow signature_def_map
-
-    Returns:
-      A saved_model exported to disk at ``export_dir``.
-    """
-    import tensorflow as tf
-    g = sess.graph
-    g._unsafe_unfinalize()           # https://github.com/tensorflow/serving/issues/363
-    builder = tf.saved_model.builder.SavedModelBuilder(export_dir)
-
-    logging.info("===== signatures: {}".format(signatures))
-    signature_def_map = {}
-    for key, sig in signatures.items():
-      signature_def_map[key] = tf.saved_model.signature_def_utils.build_signature_def(
-                inputs={ name:tf.saved_model.utils.build_tensor_info(tensor) for name, tensor in sig['inputs'].items() },
-                outputs={ name:tf.saved_model.utils.build_tensor_info(tensor) for name, tensor in sig['outputs'].items() },
-                method_name=sig['method_name'] if 'method_name' in sig else key)
-    logging.info("===== signature_def_map: {}".format(signature_def_map))
-    builder.add_meta_graph_and_variables(sess,
-                tag_set.split(','),
-                signature_def_map=signature_def_map,
-                clear_devices=True)
-    g.finalize()
-    builder.save()
+    """Convenience function to access ``TFNode.export_saved_model`` directly from this object instance."""
+    TFNode.export_saved_model(sess, export_dir, tag_set, signatures)
 
   def get_data_feed(self, train_mode=True, qname_in='input', qname_out='output', input_mapping=None):
-    return DataFeed(self.mgr, train_mode, qname_in, qname_out, input_mapping)
+    """Convenience function to access ``TFNode.DataFeed`` directly from this object instance."""
+    return TFNode.DataFeed(self.mgr, train_mode, qname_in, qname_out, input_mapping)
 
-
-class DataFeed(object):
-  """This class manages the *InputMode.SPARK* data feeding process from the perspective of the TensorFlow application.
-
-  Args:
-    :mgr: TFManager instance associated with this Python worker process.
-    :train_mode: boolean indicating if the data feed is expecting an output response (e.g. inferencing).
-    :qname_in: *INTERNAL_USE*
-    :qname_out: *INTERNAL_USE*
-    :input_mapping: *For Spark ML Pipelines only*.  Dictionary of input DataFrame columns to input TensorFlow tensors.
-  """
-  def __init__(self, mgr, train_mode=True, qname_in='input', qname_out='output', input_mapping=None):
-
-    self.mgr = mgr
-    self.train_mode = train_mode
-    self.qname_in = qname_in
-    self.qname_out = qname_out
-    self.done_feeding = False
-    self.input_tensors = [ tensor for col, tensor in sorted(input_mapping.items()) ] if input_mapping is not None else None
-
-  def next_batch(self, batch_size):
-    """Gets a batch of items from the input RDD.
-
-    If multiple tensors are provided per row in the input RDD, e.g. tuple of (tensor1, tensor2, ..., tensorN) and:
-
-    * no ``input_mapping`` was provided to the DataFeed constructor, this will return an array of ``batch_size`` tuples,
-      and the caller is responsible for separating the tensors.
-    * an ``input_mapping`` was provided to the DataFeed constructor, this will return a dictionary of N tensors,
-      with tensor names as keys and arrays of length ``batch_size`` as values.
-
-    Note: if the end of the data is reached, this may return with fewer than ``batch_size`` items.
-
-    Args:
-      :batch_size: number of items to retrieve.
-
-    Returns:
-      A batch of items or a dictionary of tensors.
-    """
-    logging.debug("next_batch() invoked")
-    queue = self.mgr.get_queue(self.qname_in)
-    tensors = [] if self.input_tensors is None else { tensor:[] for tensor in self.input_tensors }
-    count = 0
-    while count < batch_size:
-      item = queue.get(block=True)
-      if item is None:
-        # End of Feed
-        logging.info("next_batch() got None")
-        queue.task_done()
-        self.done_feeding = True
-        break
-      elif type(item) is marker.EndPartition:
-        # End of Partition
-        logging.info("next_batch() got EndPartition")
-        queue.task_done()
-        if not self.train_mode and count > 0:
-          break
-      else:
-        # Normal item
-        if self.input_tensors is None:
-          tensors.append(item)
-        else:
-          for i in range(len(self.input_tensors)):
-            tensors[self.input_tensors[i]].append(item[i])
-        count += 1
-        queue.task_done()
-    logging.debug("next_batch() returning {0} items".format(count))
-    return tensors
-
-  def should_stop(self):
-    """Check if the feed process was told to stop (by a call to ``terminate``)."""
-    return self.done_feeding
-
-  def batch_results(self, results):
-    """Push a batch of output results to the Spark output RDD of ``TFCluster.inference()``.
-
-    Note: this currently expects a one-to-one mapping of input to output data, so the length of the ``results`` array should match the length of
-    the previously retrieved batch of input data.
-
-    Args:
-      :results: array of output data for the equivalent batch of input data.
-    """
-    logging.debug("batch_results() invoked")
-    queue = self.mgr.get_queue(self.qname_out)
-    for item in results:
-      queue.put(item, block=True)
-    logging.debug("batch_results() returning data")
-
-  def terminate(self):
-    """Terminate data feeding early.
-
-    Since TensorFlow applications can often terminate on conditions unrelated to the training data (e.g. steps, accuracy, etc),
-    this method signals the data feeding process to ignore any further incoming data.  Note that Spark itself does not have a mechanism
-    to terminate an RDD operation early, so the extra partitions will still be sent to the executors (but will be ignored).  Because
-    of this, you should size your input data accordingly to avoid excessive overhead.
-    """
-    logging.info("terminate() invoked")
-    self.mgr.set('state', 'terminating')
-
-    # drop remaining items in the queue
-    queue = self.mgr.get_queue(self.qname_in)
-    count = 0
-    done = False
-    while not done:
-      try:
-        queue.get(block=True, timeout=5)
-        queue.task_done()
-        count += 1
-      except Empty:
-        logging.info("dropped {0} items from queue".format(count))
-        done = True
 
 class TFSparkNode(object):
   """Low-level functions used by the high-level TFCluster APIs to manage cluster state.

--- a/tensorflowonspark/TFSparkNode.py
+++ b/tensorflowonspark/TFSparkNode.py
@@ -263,7 +263,7 @@ def run(fn, tf_args, cluster_meta, tensorboard, log_dir, queues, background):
         raise Exception("Background mode relies reuse of python worker on Spark. This config 'spark.python.worker.reuse' is not enabled on Spark. Please enable it before using background.")
 
     def wrapper_fn(args, context):
-      """Wrapper function that sets the sys.argv of the executor and starts the tf.train.server."""
+      """Wrapper function that sets the sys.argv of the executor."""
       if isinstance(args, list):
         sys.argv = args
       fn(args, context)

--- a/tensorflowonspark/TFSparkNode.py
+++ b/tensorflowonspark/TFSparkNode.py
@@ -8,17 +8,14 @@ from __future__ import division
 from __future__ import nested_scopes
 from __future__ import print_function
 
-import getpass
 import logging
 import os
 import sys
 import platform
 import socket
-import time
 import subprocess
 import multiprocessing
 import uuid
-from six.moves.queue import Empty
 
 from . import TFManager
 from . import TFNode

--- a/tensorflowonspark/util.py
+++ b/tensorflowonspark/util.py
@@ -21,6 +21,6 @@ def find_in_path(path, file):
   """Find a file in a given path string."""
   for p in path.split(os.pathsep):
     candidate = os.path.join(p, file)
-    if (os.path.exists(os.path.join(p, file))):
+    if os.path.exists(candidate) and os.path.isfile(candidate):
       return candidate
   return False


### PR DESCRIPTION
For Review Only.

- Merges TFNode functionality into the TFNodeContext object that's passed into the TensorFlow `map_fn`.
- Adds option to start the `tf.train.Server` before invoking the user's `map_fn`.
- Maintains backwards-compatibility for existing code.
- Removes deprecated APIs.