### PR TITLE
Allow running PS nodes on the spark driver

### DIFF
--- a/examples/mnist/spark/mnist_spark.py
+++ b/examples/mnist/spark/mnist_spark.py
@@ -40,6 +40,7 @@ parser.add_argument("-s", "--steps", help="maximum number of steps", type=int, d
 parser.add_argument("-tb", "--tensorboard", help="launch tensorboard process", action="store_true")
 parser.add_argument("-X", "--mode", help="train|inference", default="train")
 parser.add_argument("-c", "--rdma", help="use rdma connection", default=False)
+parser.add_argument("-p", "--driver_ps_nodes", help="run tensorflow PS node on driver locally", default=False)
 args = parser.parse_args()
 print("args:",args)
 
@@ -67,7 +68,8 @@ else:
   print("zipping images and labels")
   dataRDD = images.zip(labels)
 
-cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK, log_dir=args.model)
+cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK,
+                        driver_ps_nodes=args.driver_ps_nodes, log_dir=args.model)
 if args.mode == "train":
   cluster.train(dataRDD, args.epochs)
 else:

--- a/examples/mnist/spark/mnist_spark_dataset.py
+++ b/examples/mnist/spark/mnist_spark_dataset.py
@@ -36,6 +36,7 @@ parser.add_argument("-s", "--steps", help="maximum number of steps", type=int, d
 parser.add_argument("-tb", "--tensorboard", help="launch tensorboard process", action="store_true")
 parser.add_argument("-X", "--mode", help="train|inference", default="train")
 parser.add_argument("-c", "--rdma", help="use rdma connection", default=False)
+parser.add_argument("-p", "--driver_ps_nodes", help="run tensorflow PS node on driver locally", default=False)
 args = parser.parse_args()
 print("args:",args)
 
@@ -59,7 +60,8 @@ else:  # args.format == "csv":
   print("zipping images and labels")
   dataRDD = images.zip(labels)
 
-cluster = TFCluster.run(sc, mnist_dist_dataset.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK)
+cluster = TFCluster.run(sc, mnist_dist_dataset.map_fun, args, args.cluster_size, num_ps, args.tensorboard,
+                        TFCluster.InputMode.SPARK, driver_ps_nodes=args.driver_ps_nodes)
 if args.mode == "train":
   cluster.train(dataRDD, args.epochs)
 else:

--- a/examples/mnist/spark/mnist_spark_pipeline.py
+++ b/examples/mnist/spark/mnist_spark_pipeline.py
@@ -37,6 +37,7 @@ parser.add_argument("--model_dir", help="HDFS path to save/load model during tra
 parser.add_argument("--export_dir", help="HDFS path to export model", type=str)
 parser.add_argument("--cluster_size", help="number of nodes in the cluster", type=int, default=num_executors)
 parser.add_argument("--num_ps", help="number of PS nodes in cluster", type=int, default=1)
+parser.add_argument("--driver_ps_nodes", help="run tensorflow PS node on driver locally", default=False)
 parser.add_argument("--protocol", help="Tensorflow network protocol (grpc|rdma)", default="grpc")
 parser.add_argument("--steps", help="maximum number of steps", type=int, default=1000)
 parser.add_argument("--tensorboard", help="launch tensorboard process", action="store_true")
@@ -80,6 +81,7 @@ if args.train:
           .setExportDir(args.export_dir) \
           .setClusterSize(args.cluster_size) \
           .setNumPS(args.num_ps) \
+          .setDriverPSNodes(args.driver_ps_nodes) \
           .setProtocol(args.protocol) \
           .setTensorboard(args.tensorboard) \
           .setEpochs(args.epochs) \

--- a/examples/mnist/streaming/mnist_spark.py
+++ b/examples/mnist/streaming/mnist_spark.py
@@ -40,6 +40,7 @@ parser.add_argument("-s", "--steps", help="maximum number of steps", type=int, d
 parser.add_argument("-tb", "--tensorboard", help="launch tensorboard process", action="store_true")
 parser.add_argument("-X", "--mode", help="train|inference", default="train")
 parser.add_argument("-c", "--rdma", help="use rdma connection", default=False)
+parser.add_argument("-p", "--driver_ps_nodes", help="run tensorflow PS node on driver locally", default=False)
 args = parser.parse_args()
 print("args:",args)
 
@@ -55,7 +56,8 @@ def parse(ln):
 stream = ssc.textFileStream(args.images)
 imageRDD = stream.map(lambda ln: parse(ln))
 
-cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK)
+cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard,
+                        TFCluster.InputMode.SPARK, driver_ps_nodes=args.driver_ps_nodes)
 if args.mode == "train":
   cluster.train(imageRDD)
 else:

--- a/examples/mnist/tf/mnist_spark.py
+++ b/examples/mnist/tf/mnist_spark.py
@@ -38,12 +38,14 @@ parser.add_argument("-s", "--steps", help="maximum number of steps", type=int, d
 parser.add_argument("-tb", "--tensorboard", help="launch tensorboard process", action="store_true")
 parser.add_argument("-X", "--mode", help="train|inference", default="train")
 parser.add_argument("-c", "--rdma", help="use rdma connection", default=False)
+parser.add_argument("-p", "--driver_ps_nodes", help="run tensorflow PS node on driver locally", default=False)
 args = parser.parse_args()
 print("args:",args)
 
 
 print("{0} ===== Start".format(datetime.now().isoformat()))
-cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.TENSORFLOW, log_dir=args.model)
+cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.TENSORFLOW,
+                        driver_ps_nodes=args.driver_ps_nodes, log_dir=args.model)
 cluster.shutdown()
 
 print("{0} ===== Stop".format(datetime.now().isoformat()))

--- a/examples/mnist/tf/mnist_spark_dataset.py
+++ b/examples/mnist/tf/mnist_spark_dataset.py
@@ -34,12 +34,14 @@ parser.add_argument("-s", "--steps", help="maximum number of steps", type=int, d
 parser.add_argument("-tb", "--tensorboard", help="launch tensorboard process", action="store_true")
 parser.add_argument("-X", "--mode", help="train|inference", default="train")
 parser.add_argument("-c", "--rdma", help="use rdma connection", default=False)
+parser.add_argument("-p", "--driver_ps_nodes", help="run tensorflow PS node on driver locally", default=False)
 args = parser.parse_args()
 print("args:",args)
 
 
 print("{0} ===== Start".format(datetime.now().isoformat()))
-cluster = TFCluster.run(sc, mnist_dist_dataset.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.TENSORFLOW)
+cluster = TFCluster.run(sc, mnist_dist_dataset.map_fun, args, args.cluster_size, num_ps, args.tensorboard,
+                        TFCluster.InputMode.TENSORFLOW, driver_ps_nodes=args.driver_ps_nodes)
 cluster.shutdown()
 
 print("{0} ===== Stop".format(datetime.now().isoformat()))

--- a/examples/mnist/tf/mnist_spark_pipeline.py
+++ b/examples/mnist/tf/mnist_spark_pipeline.py
@@ -38,6 +38,7 @@ parser.add_argument("--export_dir", help="HDFS path to export model", type=str)
 parser.add_argument("--tfrecord_dir", help="HDFS path to temporarily save DataFrame to disk", type=str)
 parser.add_argument("--cluster_size", help="number of nodes in the cluster", type=int, default=num_executors)
 parser.add_argument("--num_ps", help="number of PS nodes in cluster", type=int, default=1)
+parser.add_argument("--driver_ps_nodes", help="run tensorflow PS node on driver locally", default=False)
 parser.add_argument("--protocol", help="Tensorflow network protocol (grpc|rdma)", default="grpc")
 parser.add_argument("--readers", help="number of reader/enqueue threads", type=int, default=1)
 parser.add_argument("--steps", help="maximum number of steps", type=int, default=1000)
@@ -81,6 +82,7 @@ if args.train:
           .setExportDir(args.export_dir) \
           .setClusterSize(args.cluster_size) \
           .setNumPS(args.num_ps) \
+          .setDriverPSNodes(args.driver_ps_nodes) \
           .setInputMode(TFCluster.InputMode.TENSORFLOW) \
           .setTFRecordDir(args.tfrecord_dir) \
           .setProtocol(args.protocol) \


### PR DESCRIPTION
The current behavior is to start the tensorflow PS nodes on an spark executor. This would mean wasting GPUs available on that node. These changes allow one to start the PS nodes in the driver while the workers are started on the spark executors