### PR TITLE
Remove tensorflow submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tensorflow"]
-	path = tensorflow
-	url = https://github.com/yahoo/tensorflow.git


### PR DESCRIPTION
This submodule was initially used for RDMA support, which is now merged into the main TensorFlow codebase, so it is no longer needed here.  

Note: will need to update some of the wiki docs after merge.