### PR TITLE
Fixing an issue where parameter server always reserves 1 GPU as long as TensorFlow GPU build is used

### DIFF
--- a/tensorflowonspark/TFNode.py
+++ b/tensorflowonspark/TFNode.py
@@ -70,7 +70,7 @@ def start_cluster_server(ctx, num_gpus=1, rdma=False):
   cluster_spec = ctx.cluster_spec
   logging.info("{0}: Cluster spec: {1}".format(ctx.worker_num, cluster_spec))
 
-  if tf.test.is_built_with_cuda():
+  if tf.test.is_built_with_cuda() and num_gpus > 0:
     # GPU
     gpu_initialized = False
     retries = 3


### PR DESCRIPTION
This PR provides a fix for issue described here: https://github.com/yahoo/TensorFlowOnSpark/issues/275