### PR TITLE
update tensorflow-hadoop dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ docs/.doctrees
 *.log
 *.jar
 .DS_Store
+target
+test-data
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
         </dependency>
         <dependency>
             <groupId>org.tensorflow</groupId>
-            <artifactId>tensorflow-hadoop</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <artifactId>hadoop</artifactId>
+            <version>${tensorflow.version}</version>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>


### PR DESCRIPTION
Recent commits to tensorflow-ecosystem rendered TensorFlowOnSpark unbuildable: https://github.com/tensorflow/ecosystem/tree/master/hadoop