### PR TITLE
Workaround for firewall proxy isue with get_ip_address

### DIFF
--- a/tensorflowonspark/util.py
+++ b/tensorflowonspark/util.py
@@ -9,12 +9,23 @@ from __future__ import print_function
 
 import os
 import socket
+import errno
+from socket import error as socket_error
 
 def get_ip_address():
   """Simple utility to get host IP address."""
-  s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-  s.connect(("8.8.8.8", 80))
-  return s.getsockname()[0]
+  try:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    ip_address =  s.getsockname()[0]
+  except socket_error as sockerr:
+    if sockerr.errno != errno.ENETUNREACH:
+      raise sockerr
+    ip_address = socket.gethostbyname(socket.getfqdn())
+  finally:
+    s.close()
+   
+  return ip_address
 
 
 def find_in_path(path, file):


### PR DESCRIPTION
Currently there is an issue with get_ip_address method in utils.py file which prevents the driver from starting TF cluster. It does not work with corporate firewall proxy servers. Since it is making use of raw socket APIs, we can't use HTTP_PROXY also, even though the socket connection is to HTTP port. I am surprised that not many people ran into this issue  except the one mentioned in #208 where the person had to resort to using VMs on a single node instead of different physical nodes. 

I  ran into this issue in my lab and I had to fix it to try TFOS. 

This PR works around the issue by  catching the exception (ENETUNREACH - 101)  with proxy and tries gethostname with FQDN. Normally on Hadoop clusters FQDNs are used for all the nodes in the cluster, so this should work most of the times. This PR should not cause any regression as the new code is only tried after the existing approach fails.


Here is the log with issue:
-------------------------------
2018-07-06T11:55:57.471247 ===== Start
zipping images and labels
2018-07-06 11:55:57,908 INFO (MainThread-54025) Reserving TFSparkNodes 
2018-07-06 11:55:57,908 INFO (MainThread-54025) cluster_template: {'ps': [0], 'worker': [1, 2, 3]}
Traceback (most recent call last):
  File "mnist_spark.py", line 68, in <module>
    cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, num_ps, args.tensorboard, TFCluster.InputMode.SPARK, log_dir=args.model)
  File "/usr/lib/python2.7/site-packages/tensorflowonspark/TFCluster.py", line 252, in run
    server_addr = server.start()
  File "/usr/lib/python2.7/site-packages/tensorflowonspark/reservation.py", line 155, in start
    host = util.get_ip_address()
  File "/usr/lib/python2.7/site-packages/tensorflowonspark/util.py", line 16, in get_ip_address
    s.connect(("8.8.8.8", 80))
  File "/usr/lib64/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 101] Network is unreachable

Here is the log after fixing the issue with the changes in this PR:
---------------------------------------------------------------------
2018-07-16T06:58:34.850516 ===== Start
zipping images and labels
2018-07-16 06:58:35,274 INFO (MainThread-38830) Reserving TFSparkNodes
2018-07-16 06:58:35,274 INFO (MainThread-38830) cluster_template: {'ps': [0], 'worker': [1, 2, 3]}
2018-07-16 06:58:35,276 INFO (MainThread-38830) listening for reservations at ('172.30.236.60', 40288)
2018-07-16 06:58:35,276 INFO (MainThread-38830) Starting TensorFlow on executors
2018-07-16 06:58:35,282 INFO (MainThread-38830) Waiting for TFSparkNodes to start
2018-07-16 06:58:35,282 INFO (MainThread-38830) waiting for 4 reservations
2018-07-16 06:58:36,283 INFO (MainThread-38830) waiting for 4 reservations
2018-07-16 06:58:37,284 INFO (MainThread-38830) all reservations completed
2018-07-16 06:58:37,285 INFO (MainThread-38830) All TFSparkNodes started
