### PR TITLE
Test for sparse tensor support in pipeline API for InputMode.SPARK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 py4j
 pyspark==2.3.1
+scipy
 sphinx
 tensorflow


### PR DESCRIPTION
Note: this requires the caller to feed the sparse tensor via its constituent parts, and then assemble the sparse tensor in the TF graph.
