### PR TITLE
Enable configuring TFoS server IP and PORT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ docs/.doctrees
 target
 test-data
 dependency-reduced-pom.xml
+venv
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - export PYTHONPATH=$(pwd)
     install:
     - pip install -r requirements.txt
+    - pip install mock
     script:
     - test/run_tests.sh
   - language: python

--- a/tensorflowonspark/pipeline.py
+++ b/tensorflowonspark/pipeline.py
@@ -23,7 +23,7 @@ from pyspark.ml.pipeline import Estimator, Model
 from pyspark.sql import Row, SparkSession
 
 import tensorflow as tf
-from tensorflow.contrib.saved_model.python.saved_model import reader, signature_def_utils
+from tensorflow.contrib.saved_model.python.saved_model import reader
 from tensorflow.python.saved_model import loader
 from . import TFCluster, gpu_info, dfutil
 
@@ -503,7 +503,7 @@ def _run_model(iterator, args, tf_args):
     assert args.export_dir, "Inferencing with signature_def_key requires --export_dir argument"
     logging.info("===== loading meta_graph_def for tag_set ({0}) from saved_model: {1}".format(args.tag_set, args.export_dir))
     meta_graph_def = get_meta_graph_def(args.export_dir, args.tag_set)
-    signature = signature_def_utils.get_signature_def_by_key(meta_graph_def, args.signature_def_key)
+    signature = meta_graph_def.signature_def[args.signature_def_key]
     logging.debug("signature: {}".format(signature))
     inputs_tensor_info = signature.inputs
     logging.debug("inputs_tensor_info: {0}".format(inputs_tensor_info))

--- a/test/test_reservation.py
+++ b/test/test_reservation.py
@@ -1,9 +1,16 @@
+import os
+import sys
 import threading
 import time
 import unittest
 
+from tensorflowonspark import util
 from tensorflowonspark.reservation import Reservations, Server, Client
 
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 
 class ReservationTest(unittest.TestCase):
   def test_reservation_class(self):
@@ -47,6 +54,25 @@ class ReservationTest(unittest.TestCase):
     c.request_stop()
     time.sleep(1)
     self.assertEqual(s.done, True)
+
+  def test_reservation_enviroment_exists_get_server_ip_return_environment_value(self):
+      tfso_server = Server(5)
+      with mock.patch.dict(os.environ,{'TFOS_SERVER_HOST':'my_host_ip'}):
+        assert tfso_server.get_server_ip() == "my_host_ip"
+
+  def test_reservation_enviroment_not_exists_get_server_ip_return_actual_host_ip(self):
+    tfso_server = Server(5)
+    assert tfso_server.get_server_ip() == util.get_ip_address()
+
+  def test_reservation_enviroment_exists_start_listening_socket_return_socket_listening_to_environment_port_value(self):
+    tfso_server = Server(1)
+    with mock.patch.dict(os.environ, {'TFOS_SERVER_PORT': '9999'}):
+      assert tfso_server.start_listening_socket().getsockname()[1] == 9999
+
+  def test_reservation_enviroment_not_exists_start_listening_socket_return_socket(self):
+    tfso_server = Server(1)
+    print(tfso_server.start_listening_socket().getsockname()[1])
+    assert type(tfso_server.start_listening_socket().getsockname()[1]) == int
 
   def test_reservation_server_multi(self):
     """Test reservation server, expecting multiple reservations"""


### PR DESCRIPTION
While trying to run TFoS driver from a docker container I found out it getting reservation is getting blocked, due to the fact that reservation is using the container IP and a random PORT.

To allow using the host IP instead of the container IP and predetermined PORT I added this PR.
The container will listen to the PORT and we will bind all traffic from SERVER IP + PORT to container PORT

So if you are using docker container you need to add 2 environment variables:
TFOS_SERVER_SOCKET = the host of the container
TFOS_SERVER_HOST = port to bind to host

docker run -e TFOS_SERVER_SOCKET=4567 -e TFOS_SERVER_HOST=$HOST_IP -p 4567:4567 my_driver_image_name