### PR TITLE
handle multiple outputs with signaturedef

### DIFF
--- a/tensorflowonspark/pipeline.py
+++ b/tensorflowonspark/pipeline.py
@@ -540,7 +540,7 @@ def _run_model(iterator, args, tf_args):
   # get list of input/output tensors (by name)
   if args.signature_def_key:
     input_tensors = [inputs_tensor_info[t].name for t in input_tensor_names]
-    output_tensors = [outputs_tensor_info[output_tensor_names[0]].name]
+    output_tensors = [outputs_tensor_info[t].name for t in output_tensor_names]
   else:
     input_tensors = [t + ':0' for t in input_tensor_names]
     output_tensors = [t + ':0' for t in output_tensor_names]


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

We have created a model which looks like this

```
signature_def['serving_default']:
  The given SavedModel SignatureDef contains the following input(s):
    inputs['dense_input'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 179)
        name: Placeholder:0
    inputs['identity_input'] tensor_info:
        dtype: DT_INT64
        shape: (-1, 1)
        name: Placeholder_1:0
  The given SavedModel SignatureDef contains the following output(s):
    outputs['identity_output'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 1)
        name: identity_output/identity_output/Identity:0
    outputs['prediction'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 1)
        name: prediction/Sigmoid:0
  Method name is: tensorflow/serving/predict
```


When using TFModel and attempting to get the values back from both output tensors, it was only picking one.

The above code, when applied to a local fork, resolved the issue for us.
