### PR TITLE
remove deprecated arg

### DIFF
--- a/examples/mnist/keras/README.md
+++ b/examples/mnist/keras/README.md
@@ -5,7 +5,7 @@ Original Source: https://www.tensorflow.org/beta/tutorials/distribute/multi_work
 This is the [Multi-worker Training with Keras](https://www.tensorflow.org/beta/tutorials/distribute/multi_worker_with_keras) example, adapted for TensorFlowOnSpark.
 
 Notes:
-- This example assumes that Spark, TensorFlow, and TensorFlowOnSpark are already installed.
+- This example assumes that Spark, TensorFlow, TensorFlow Datasets, and TensorFlowOnSpark are already installed.
 
 #### Launch the Spark Standalone cluster
 

--- a/examples/mnist/keras/mnist_pipeline.py
+++ b/examples/mnist/keras/mnist_pipeline.py
@@ -50,7 +50,7 @@ def main_fun(args, ctx):
   # callbacks = [tf.keras.callbacks.ModelCheckpoint(filepath=args.model_dir)]
   tf.io.gfile.makedirs(args.model_dir)
   filepath = args.model_dir + "/weights-{epoch:04d}"
-  callbacks = [tf.keras.callbacks.ModelCheckpoint(filepath=filepath, verbose=1, load_weights_on_restart=True, save_weights_only=True)]
+  callbacks = [tf.keras.callbacks.ModelCheckpoint(filepath=filepath, verbose=1, save_weights_only=True)]
 
   with strategy.scope():
     multi_worker_model = build_and_compile_cnn_model()

--- a/examples/mnist/keras/mnist_tf.py
+++ b/examples/mnist/keras/mnist_tf.py
@@ -54,7 +54,7 @@ def main_fun(args, ctx):
   # callbacks = [tf.keras.callbacks.ModelCheckpoint(filepath=args.model_dir)]
   tf.io.gfile.makedirs(args.model_dir)
   filepath = args.model_dir + "/weights-{epoch:04d}"
-  callbacks = [tf.keras.callbacks.ModelCheckpoint(filepath=filepath, verbose=1, load_weights_on_restart=True, save_weights_only=True)]
+  callbacks = [tf.keras.callbacks.ModelCheckpoint(filepath=filepath, verbose=1, save_weights_only=True)]
 
   with strategy.scope():
     multi_worker_model = build_and_compile_cnn_model()

--- a/examples/segmentation/segmentation_spark.py
+++ b/examples/segmentation/segmentation_spark.py
@@ -151,7 +151,7 @@ def main_fun(args, ctx):
 
   tf.io.gfile.makedirs(args.model_dir)
   filepath = args.model_dir + "/weights-{epoch:04d}"
-  ckpt_callback = tf.keras.callbacks.ModelCheckpoint(filepath=filepath, verbose=1, load_weights_on_restart=True, save_weights_only=True)
+  ckpt_callback = tf.keras.callbacks.ModelCheckpoint(filepath=filepath, verbose=1, save_weights_only=True)
 
   model_history = model.fit(train_dataset, epochs=EPOCHS,
                             steps_per_epoch=STEPS_PER_EPOCH,


### PR DESCRIPTION
`load_weights_on_restart` is deprecated... and causes issues if set.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
