### PR TITLE
Add compat layer for TF2.1rc0 compatibility

### DIFF
--- a/examples/mnist/estimator/README.md
+++ b/examples/mnist/estimator/README.md
@@ -1,8 +1,8 @@
 # MNIST using Estimator
 
-Original Source: https://www.tensorflow.org/beta/tutorials/distribute/multi_worker_with_estimator
+Original Source: https://www.tensorflow.org/tutorials/distribute/multi_worker_with_estimator
 
-This is the [Multi-worker Training with Estimator](https://www.tensorflow.org/beta/tutorials/distribute/multi_worker_with_estimator) example, adapted for TensorFlowOnSpark.
+This is the [Multi-worker Training with Estimator](https://www.tensorflow.org/tutorials/distribute/multi_worker_with_estimator) example, adapted for TensorFlowOnSpark.
 
 Note: this example assumes that Spark, TensorFlow, and TensorFlowOnSpark are already installed.
 

--- a/examples/mnist/estimator/mnist_pipeline.py
+++ b/examples/mnist/estimator/mnist_pipeline.py
@@ -45,8 +45,7 @@ def main_fun(args, ctx):
       ds = tf.data.Dataset.from_generator(rdd_generator, (tf.float32, tf.float32), (tf.TensorShape([28, 28, 1]), tf.TensorShape([1])))
       return ds.batch(BATCH_SIZE)
     else:
-      raise Exception("I'm evaluating: mode={}, input_context={}".format(mode, input_context))
-
+      # read evaluation data from tensorflow_datasets directly
       def scale(image, label):
         image = tf.cast(image, tf.float32) / 255.0
         return image, label

--- a/examples/mnist/estimator/mnist_spark.py
+++ b/examples/mnist/estimator/mnist_spark.py
@@ -93,7 +93,6 @@ def main_fun(args, ctx):
         train_op=optimizer.minimize(
             loss, tf.compat.v1.train.get_or_create_global_step()))
 
-  # strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
   config = tf.estimator.RunConfig(train_distribute=strategy, save_checkpoints_steps=100)
 
   classifier = tf.estimator.Estimator(

--- a/examples/mnist/estimator/mnist_spark.py
+++ b/examples/mnist/estimator/mnist_spark.py
@@ -9,6 +9,8 @@ def main_fun(args, ctx):
   import tensorflow_datasets as tfds
   from tensorflowonspark import TFNode
 
+  strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
+
   tfds.disable_progress_bar()
 
   class StopFeedHook(tf.estimator.SessionRunHook):
@@ -91,7 +93,7 @@ def main_fun(args, ctx):
         train_op=optimizer.minimize(
             loss, tf.compat.v1.train.get_or_create_global_step()))
 
-  strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
+  # strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
   config = tf.estimator.RunConfig(train_distribute=strategy, save_checkpoints_steps=100)
 
   classifier = tf.estimator.Estimator(

--- a/examples/mnist/keras/README.md
+++ b/examples/mnist/keras/README.md
@@ -1,8 +1,8 @@
 # MNIST using Keras
 
-Original Source: https://www.tensorflow.org/beta/tutorials/distribute/multi_worker_with_keras
+Original Source: https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras
 
-This is the [Multi-worker Training with Keras](https://www.tensorflow.org/beta/tutorials/distribute/multi_worker_with_keras) example, adapted for TensorFlowOnSpark.
+This is the [Multi-worker Training with Keras](https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras) example, adapted for TensorFlowOnSpark.
 
 Notes:
 - This example assumes that Spark, TensorFlow, TensorFlow Datasets, and TensorFlowOnSpark are already installed.

--- a/examples/mnist/keras/README.md
+++ b/examples/mnist/keras/README.md
@@ -130,7 +130,7 @@ For batch inferencing use cases, you can use Spark to run multiple single-node T
     ${TFoS_HOME}/examples/mnist/keras/mnist_inference.py \
     --cluster_size ${SPARK_WORKER_INSTANCES} \
     --images_labels ${TFoS_HOME}/data/mnist/tfr/test \
-    --export_dir ${TFoS_HOME}/mnist_export \
+    --export_dir $SAVED_MODEL \
     --output ${TFoS_HOME}/predictions
 
 #### Train and Inference via Spark ML Pipeline API

--- a/examples/mnist/keras/README.md
+++ b/examples/mnist/keras/README.md
@@ -130,7 +130,7 @@ For batch inferencing use cases, you can use Spark to run multiple single-node T
     ${TFoS_HOME}/examples/mnist/keras/mnist_inference.py \
     --cluster_size ${SPARK_WORKER_INSTANCES} \
     --images_labels ${TFoS_HOME}/data/mnist/tfr/test \
-    --export_dir $SAVED_MODEL \
+    --export_dir ${SAVED_MODEL} \
     --output ${TFoS_HOME}/predictions
 
 #### Train and Inference via Spark ML Pipeline API

--- a/examples/mnist/keras/mnist_pipeline.py
+++ b/examples/mnist/keras/mnist_pipeline.py
@@ -65,11 +65,9 @@ def main_fun(args, ctx):
 
   multi_worker_model.fit(x=ds, epochs=args.epochs, steps_per_epoch=max_steps_per_worker, callbacks=callbacks)
 
-  if ctx.job_name == 'chief':
-    from tensorflow_estimator.python.estimator.export import export_lib
-    export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
-    tf.keras.experimental.export_saved_model(multi_worker_model, export_dir)
-    # multi_worker_model.save(args.model_dir, save_format='tf')
+  from tensorflow_estimator.python.estimator.export import export_lib
+  export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
+  multi_worker_model.save(export_dir, save_format='tf')
 
   # terminating feed tells spark to skip processing further partitions
   tf_feed.terminate()

--- a/examples/mnist/keras/mnist_pipeline.py
+++ b/examples/mnist/keras/mnist_pipeline.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 def main_fun(args, ctx):
   import numpy as np
   import tensorflow as tf
-  from tensorflowonspark import TFNode
+  from tensorflowonspark import compat, TFNode
 
   strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
 
@@ -67,7 +67,7 @@ def main_fun(args, ctx):
 
   from tensorflow_estimator.python.estimator.export import export_lib
   export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
-  multi_worker_model.save(export_dir, save_format='tf')
+  compat.export_saved_model(multi_worker_model, export_dir, ctx.job_name == 'chief')
 
   # terminating feed tells spark to skip processing further partitions
   tf_feed.terminate()

--- a/examples/mnist/keras/mnist_spark.py
+++ b/examples/mnist/keras/mnist_spark.py
@@ -65,11 +65,9 @@ def main_fun(args, ctx):
 
   multi_worker_model.fit(x=ds, epochs=args.epochs, steps_per_epoch=max_steps_per_worker, callbacks=callbacks)
 
-  if ctx.job_name == 'chief':
-    from tensorflow_estimator.python.estimator.export import export_lib
-    export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
-    tf.keras.experimental.export_saved_model(multi_worker_model, export_dir)
-    # multi_worker_model.save(args.model_dir, save_format='tf')
+  from tensorflow_estimator.python.estimator.export import export_lib
+  export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
+  multi_worker_model.save(export_dir, save_format='tf')
 
   # terminating feed tells spark to skip processing further partitions
   tf_feed.terminate()

--- a/examples/mnist/keras/mnist_spark.py
+++ b/examples/mnist/keras/mnist_spark.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 def main_fun(args, ctx):
   import numpy as np
   import tensorflow as tf
-  from tensorflowonspark import TFNode
+  from tensorflowonspark import compat, TFNode
 
   strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
 
@@ -67,7 +67,7 @@ def main_fun(args, ctx):
 
   from tensorflow_estimator.python.estimator.export import export_lib
   export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
-  multi_worker_model.save(export_dir, save_format='tf')
+  compat.export_saved_model(multi_worker_model, export_dir, ctx.job_name == 'chief')
 
   # terminating feed tells spark to skip processing further partitions
   tf_feed.terminate()

--- a/examples/mnist/keras/mnist_tf.py
+++ b/examples/mnist/keras/mnist_tf.py
@@ -60,11 +60,9 @@ def main_fun(args, ctx):
     multi_worker_model = build_and_compile_cnn_model()
   multi_worker_model.fit(x=train_datasets, epochs=args.epochs, steps_per_epoch=args.steps_per_epoch, callbacks=callbacks)
 
-  if ctx.job_name == 'chief':
-    from tensorflow_estimator.python.estimator.export import export_lib
-    export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
-    tf.keras.experimental.export_saved_model(multi_worker_model, export_dir)
-    # multi_worker_model.save(args.model_dir, save_format='tf')
+  from tensorflow_estimator.python.estimator.export import export_lib
+  export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
+  multi_worker_model.save(export_dir, save_format='tf')
 
 
 if __name__ == '__main__':

--- a/examples/mnist/keras/mnist_tf.py
+++ b/examples/mnist/keras/mnist_tf.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 def main_fun(args, ctx):
   import tensorflow_datasets as tfds
   import tensorflow as tf
+  from tensorflowonspark import compat
+
   tfds.disable_progress_bar()
 
   strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
@@ -62,7 +64,7 @@ def main_fun(args, ctx):
 
   from tensorflow_estimator.python.estimator.export import export_lib
   export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
-  multi_worker_model.save(export_dir, save_format='tf')
+  compat.export_saved_model(multi_worker_model, export_dir, ctx.job_name == 'chief')
 
 
 if __name__ == '__main__':

--- a/examples/mnist/keras/mnist_tf_ds.py
+++ b/examples/mnist/keras/mnist_tf_ds.py
@@ -86,11 +86,9 @@ def main_fun(args, ctx):
     multi_worker_model = build_and_compile_cnn_model()
   multi_worker_model.fit(x=train_datasets, epochs=args.epochs, steps_per_epoch=steps_per_epoch, callbacks=callbacks)
 
-  if ctx.job_name == 'chief':
-    from tensorflow_estimator.python.estimator.export import export_lib
-    export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
-    tf.keras.experimental.export_saved_model(multi_worker_model, export_dir)
-    # multi_worker_model.save(args.model_dir, save_format='tf')
+  from tensorflow_estimator.python.estimator.export import export_lib
+  export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
+  multi_worker_model.save(export_dir, save_format='tf')
 
 
 if __name__ == '__main__':

--- a/examples/mnist/keras/mnist_tf_ds.py
+++ b/examples/mnist/keras/mnist_tf_ds.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 def main_fun(args, ctx):
   """Example demonstrating loading TFRecords directly from disk (e.g. HDFS) without tensorflow_datasets."""
   import tensorflow as tf
+  from tensorflowonspark import compat
 
   strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
 
@@ -88,7 +89,7 @@ def main_fun(args, ctx):
 
   from tensorflow_estimator.python.estimator.export import export_lib
   export_dir = export_lib.get_timestamped_export_dir(args.export_dir)
-  multi_worker_model.save(export_dir, save_format='tf')
+  compat.export_saved_model(multi_worker_model, export_dir, ctx.job_name == 'chief')
 
 
 if __name__ == '__main__':

--- a/examples/segmentation/README.md
+++ b/examples/segmentation/README.md
@@ -1,8 +1,8 @@
 # Image Segmentation
 
-Original Source: https://www.tensorflow.org/beta/tutorials/images/segmentation
+Original Source: https://www.tensorflow.org/tutorials/images/segmentation
 
-This code is based on the [Image Segmentation](https://www.tensorflow.org/beta/tutorials/images/segmentation) notebook example, converted to a single-node TensorFlow python app, then converted into a distributed TensorFlow app using the `MultiWorkerMirroredStrategy`, and then finally adapted for TensorFlowOnSpark.  Compare the different versions to see the conversion steps involved at each stage.
+This code is based on the [Image Segmentation](https://www.tensorflow.org/tutorials/images/segmentation) notebook example, converted to a single-node TensorFlow python app, then converted into a distributed TensorFlow app using the `MultiWorkerMirroredStrategy`, and then finally adapted for TensorFlowOnSpark.  Compare the different versions to see the conversion steps involved at each stage.
 
 Notes: 
 - this example assumes that Spark, TensorFlow, and TensorFlowOnSpark are already installed.

--- a/examples/segmentation/segmentation_spark.py
+++ b/examples/segmentation/segmentation_spark.py
@@ -159,7 +159,15 @@ def main_fun(args, ctx):
                             validation_steps=VALIDATION_STEPS,
                             validation_data=test_dataset)
 
-  model.save(args.export_dir, save_format='tf')
+  if tf.__version__ == '2.0.0':
+    # Workaround for: https://github.com/tensorflow/tensorflow/issues/30251
+    # Save model locally as h5py and reload it w/o distribution strategy
+    if ctx.job_name == 'chief':
+      model.save(args.model_dir + ".h5")
+      new_model = tf.keras.models.load_model(args.model_dir + ".h5")
+      tf.keras.experimental.export_saved_model(new_model, args.export_dir)
+  else:
+    model.save(args.export_dir, save_format='tf')
 
 
 if __name__ == '__main__':

--- a/examples/segmentation/segmentation_spark.py
+++ b/examples/segmentation/segmentation_spark.py
@@ -159,18 +159,7 @@ def main_fun(args, ctx):
                             validation_steps=VALIDATION_STEPS,
                             validation_data=test_dataset)
 
-  if ctx.job_name == 'chief':
-    # Workaround for: https://github.com/tensorflow/tensorflow/issues/30251
-    print("===== saving h5py model")
-    model.save(args.model_dir + ".h5")
-    print("===== re-loading model w/o DistributionStrategy")
-    new_model = tf.keras.models.load_model(args.model_dir + ".h5")
-    print("===== exporting saved_model")
-    tf.keras.experimental.export_saved_model(new_model, args.export_dir)
-    print("===== done exporting")
-  else:
-    print("===== sleeping")
-    time.sleep(90)
+  model.save(args.export_dir, save_format='tf')
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 h5py>=2.9.0
 numpy>=1.14.0
+packaging
 py4j==0.10.7
 pyspark
 scipy

--- a/tensorflowonspark/compat.py
+++ b/tensorflowonspark/compat.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Yahoo Inc / Verizon Media
+# Licensed under the terms of the Apache 2.0 license.
+# Please see LICENSE file in the project root for terms.
+"""Helper functions to abstract API changes between TensorFlow versions."""
+
+import tensorflow as tf
+
+TF_VERSION = tf.__version__
+
+
+def export_saved_model(model, export_dir, is_chief=False):
+  if TF_VERSION == '2.0.0':
+    if is_chief:
+      tf.keras.experimental.export_saved_model(model, export_dir)
+  else:
+    model.save(export_dir, save_format='tf')
+
+
+def disable_auto_shard(options):
+  if TF_VERSION == '2.0.0':
+    options.experimental_distribute.auto_shard = False
+  else:
+    options.experimental_distribute.auto_shard_policy = tf.data.experimental.AutoShardPolicy.OFF

--- a/tensorflowonspark/pipeline.py
+++ b/tensorflowonspark/pipeline.py
@@ -451,6 +451,7 @@ class TFModel(Model, TFParams,
 # global on each python worker process on the executors
 pred_fn = None           # saved_model prediction function/signature.
 pred_args = None         # args provided to the _run_model() method.  Any change will invalidate the pred_fn.
+saved_model = None
 
 
 def _run_model(iterator, args, tf_args):
@@ -471,7 +472,7 @@ def _run_model(iterator, args, tf_args):
   input_tensor_names = [tensor for col, tensor in sorted(args.input_mapping.items())]
   output_tensor_names = [tensor for tensor, col in sorted(args.output_mapping.items())]
 
-  global pred_fn, pred_args
+  global pred_fn, pred_args, saved_model
 
   # cache saved_model pred_fn to avoid reloading the model for each partition
   if not pred_fn or args != pred_args:

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -151,6 +151,7 @@ class PipelineTest(test.SparkTest):
                   .setModelDir(self.model_dir) \
                   .setExportDir(self.export_dir) \
                   .setClusterSize(self.num_workers) \
+                  .setMasterNode("chief") \
                   .setNumPS(0) \
                   .setBatchSize(1) \
                   .setEpochs(1)


### PR DESCRIPTION
... and re-introduce compatibility w/ TF1.x APIs (except for InputMode.TENSORFLOW support in the ML Pipelines API... which is still no longer supported, since that API is driven from Spark DataFrames).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
