### PR TITLE
use list_physical_devices to avoid runtime initialization

### DIFF
--- a/tensorflowonspark/compat.py
+++ b/tensorflowonspark/compat.py
@@ -26,4 +26,4 @@ def is_gpu_available():
   if version.parse(tf.__version__) < version.parse('2.1.0'):
     return tf.test.is_built_with_cuda()
   else:
-    return len(tf.config.list_logical_devices('GPU')) > 0
+    return len(tf.config.list_physical_devices('GPU')) > 0

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -94,7 +94,6 @@ class PipelineTest(test.SparkTest):
       import tensorflow as tf
       from tensorflowonspark import TFNode
 
-      tf.compat.v1.disable_eager_execution()
       tf.compat.v1.reset_default_graph()
       strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
 


### PR DESCRIPTION
To avoid `RuntimeError: Collective ops must be configured at program startup` when using `MultiWorkerMirroredStrategy`.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
