### PR TITLE
list_files in inference examples should be deterministically

### DIFF
--- a/examples/mnist/estimator/mnist_inference.py
+++ b/examples/mnist/estimator/mnist_inference.py
@@ -47,7 +47,7 @@ def inference(it, num_workers, args):
     return (image, label)
 
   # define a new tf.data.Dataset (for inferencing)
-  ds = tf.data.Dataset.list_files("{}/part-*".format(args.images_labels))
+  ds = tf.data.Dataset.list_files("{}/part-*".format(args.images_labels), shuffle=False)
   ds = ds.shard(num_workers, worker_num)
   ds = ds.interleave(tf.data.TFRecordDataset)
   ds = ds.map(parse_tfr)

--- a/examples/mnist/keras/mnist_inference.py
+++ b/examples/mnist/keras/mnist_inference.py
@@ -38,7 +38,7 @@ def inference(args, ctx):
     return (image, label)
 
   # define a new tf.data.Dataset (for inferencing)
-  ds = tf.data.Dataset.list_files("{}/part-*".format(args.images_labels))
+  ds = tf.data.Dataset.list_files("{}/part-*".format(args.images_labels), shuffle=False)
   ds = ds.shard(ctx.num_workers, ctx.worker_num)
   ds = ds.interleave(tf.data.TFRecordDataset)
   ds = ds.map(parse_tfr)


### PR DESCRIPTION
In reference mode, we do manual sharding in each single-node TF instances, so we have to make sure we get input filenames in a deterministic order which is not the default behavior of method `tf.data.Dataset.list_files` according to [[TF doc]](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#list_files).


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
