### PR TITLE
docs: fix simple typo, mutliple -> multiple

### DIFF
--- a/examples/resnet/resnet_cifar_dist.py
+++ b/examples/resnet/resnet_cifar_dist.py
@@ -224,7 +224,7 @@ def run(flags_obj):
         steps_per_epoch=steps_per_epoch)
     callbacks.append(lr_callback)
 
-  # if mutliple epochs, ignore the train_steps flag.
+  # if multiple epochs, ignore the train_steps flag.
   if train_epochs <= 1 and flags_obj.train_steps:
     steps_per_epoch = min(flags_obj.train_steps, steps_per_epoch)
     train_epochs = 1

--- a/examples/resnet/resnet_cifar_main.py
+++ b/examples/resnet/resnet_cifar_main.py
@@ -224,7 +224,7 @@ def run(flags_obj):
         steps_per_epoch=steps_per_epoch)
     callbacks.append(lr_callback)
 
-  # if mutliple epochs, ignore the train_steps flag.
+  # if multiple epochs, ignore the train_steps flag.
   if train_epochs <= 1 and flags_obj.train_steps:
     steps_per_epoch = min(flags_obj.train_steps, steps_per_epoch)
     train_epochs = 1


### PR DESCRIPTION
There is a small typo in examples/resnet/resnet_cifar_dist.py, examples/resnet/resnet_cifar_main.py.

Should read `multiple` rather than `mutliple`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md