### PR TITLE
allow deferred release of reserved port

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -69,7 +69,7 @@ jobs:
 
   publish_documentation:
     template: python/documentation
-    requires: [publish_test_pypi]
+    requires: [publish_pypi]
     steps:
       - update_version: |
           echo 'using version from setup.cfg'

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -69,7 +69,7 @@ jobs:
 
   publish_documentation:
     template: python/documentation
-    requires: [~commit]
+    requires: [publish_test_pypi]
     steps:
       - update_version: |
           echo 'using version from setup.cfg'

--- a/tensorflowonspark/TFNode.py
+++ b/tensorflowonspark/TFNode.py
@@ -208,6 +208,16 @@ def export_saved_model(sess, export_dir, tag_set, signatures):
   builder.save()
 
 
+def release_port(ctx):
+  """Closes the temporary socket created to assign a port to the TF node."""
+  if ctx.tmp_socket is not None:
+    logger.info("Releasing assigned port: {}".format(ctx.tmp_socket.getsockname()))
+    ctx.tmp_socket.close()
+    ctx.tmp_socket = None
+  else:
+    logger.warning("release_port() invoked with no bound socket.")
+
+
 def batch_results(mgr, results, qname='output'):
   """*DEPRECATED*. Use TFNode.DataFeed class instead."""
   raise Exception("DEPRECATED: Use TFNode.DataFeed class instead")

--- a/tests/test.py
+++ b/tests/test.py
@@ -21,6 +21,7 @@ class SparkTest(unittest.TestCase):
     assert spark_jars, "Please add path to tensorflow/ecosystem/hadoop jar to SPARK_CLASSPATH."
 
     cls.conf = SparkConf().set('spark.jars', spark_jars).set('spark.scheduler.barrier.maxConcurrentTasksCheck.maxFailures', 3)
+
     cls.sc = SparkContext(master, cls.__name__, conf=cls.conf)
     cls.spark = SparkSession.builder.getOrCreate()
 


### PR DESCRIPTION
- adds option to defer release of reserved/assigned port to user map_fn (instead of automatically releasing just prior invoking map_fn).
- trigger doc build after pypi publish.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
