### PR TITLE
use TaskContext.get to avoid creating instance in unit tests

### DIFF
--- a/tests/test_TFSparkNode.py
+++ b/tests/test_TFSparkNode.py
@@ -112,6 +112,7 @@ class TFSparkNodeTest(unittest.TestCase):
     mock_available.return_value = True
     mock_get_gpus.return_value = ['0']
     mock_spark_resources.return_value = True
+    mock_context.get.return_value = mock_context.return_value
     mock_context_instance = mock_context.return_value
     mock_context_instance.resources.return_value = {'gpu': type("ResourceInformation", (object,), {"addresses": ['0']})}
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
